### PR TITLE
Fix devdraw's title and "open in top" on OSX and acme's infinite loop

### DIFF
--- a/src/cmd/devdraw/cocoa-screen.m
+++ b/src/cmd/devdraw/cocoa-screen.m
@@ -98,7 +98,6 @@ threadmain(int argc, char **argv)
 	[NSApplication sharedApplication];
 	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 	[NSApp setDelegate:[appdelegate new]];
-	[NSApp activateIgnoringOtherApps:YES];
 	[NSApp run];
 }
 
@@ -345,6 +344,8 @@ makewin(char *s)
 		initWithContentRect:r
 		styleMask:Winstyle
 		backing:NSBackingStoreBuffered defer:NO];
+	[w setTitle:@"devdraw"];
+
 	if(!set)
 		[w center];
 #if OSX_VERSION >= 100700
@@ -366,6 +367,8 @@ makewin(char *s)
 	win.isofs = 0;
 	win.content = [contentview new];
 	[WIN setContentView:win.content];
+
+	topwin();
 }
 
 static Memimage*

--- a/src/libdraw/string.c
+++ b/src/libdraw/string.c
@@ -78,7 +78,7 @@ _string(Image *dst, Point pt, Image *src, Point sp, Font *f, char *s, Rune *r, i
 	}else
 		rptr = &r;
 	sf = nil;
-	while((*s || *r) && len){
+	while((*s || *r) && len > 0){
 		max = Max;
 		if(len < max)
 			max = len;


### PR DESCRIPTION
On OSX 10.10, when you open an application that depends on devdraw, the
title bar only shows the first letter of the application's name. The
patch sets a default title as soon as the window is created, which
fixes this issue.

On OSX 10.10, when you open an application that depends on devdraw, this
application is opened in top of other windows, however the menu bar is
not updated. The patch calls topwin() at the end of makewin() in
src/cmd/devdraw/cocoa-screen.m .

An infinite loop has been detected in libdraw that affects acme. It
can be reproduced following the following steps in acme:
    1. Open a new "win"
    2. Execute any command, e.g. "ls"
    3. Press "ESC"
    4. Press left
    5. Press "ESC"
    6. Press "ESC"
    7. Acme freezes up
This patch makes sure that len is greater that 0 in _string() at
/src/libdraw/string.c:81
