### PR TITLE
9pfuse: Disable glibc workaround for O_LARGEFILE on ARM

### DIFF
--- a/src/cmd/9pfuse/main.c
+++ b/src/cmd/9pfuse/main.c
@@ -34,8 +34,11 @@
  * 0100000 in the kernel) at each file open. FUSE is all too
  * happy to pass the flag onto us, where we'd have no idea what
  * to do with it if we trusted glibc.
+ *
+ * On ARM however, the O_LARGEFILE is set correctly.
  */
-#if defined(__linux__)
+
+#if defined(__linux__) && !defined(__arm__)
 #  undef O_LARGEFILE
 #  define O_LARGEFILE 0100000
 #endif


### PR DESCRIPTION
9pfuse fails on ARM when O_LARGEFILE is supported. glibc does define O_LARGEFILE properly on ARM, and the value is different than what that this workaround suggests, causing it to wrongly detect bad flags.
