### PR TITLE
fontsrv dependency testing for OSX

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -125,20 +125,20 @@ if [ `uname` = Darwin ]; then
 	rm -f ./a.out
 fi
 
-if [ `uname` != Darwin ]; then
-	# Determine whether fontsrv X11 files are available.
-	rm -f a.out
-	gcc -o a.out -c -Iinclude -I/usr/include -I/usr/local/include -I/usr/include/freetype2 -I/usr/local/include/freetype2 src/cmd/fontsrv/x11.c >/dev/null 2>&1
-	if [ -f a.out ]; then
-		echo "	fontsrv dependencies found."
-		echo "FONTSRV=fontsrv" >>$PLAN9/config
-	else
-		echo "	fontsrv dependencies not found."
-		echo "FONTSRV=" >>$PLAN9/config
-		rm -f bin/fontsrv
-	fi
-	rm -f a.out
+
+# Determine whether fontsrv X11 files are available.
+rm -f a.out
+gcc -o a.out -c -Iinclude -I/usr/include -I/usr/local/include -I/opt/X11/include -I/opt/X11/include/freetype2 -I/usr/include/freetype2 -I/usr/local/include/freetype2 src/cmd/fontsrv/x11.c >/dev/null 2>&1
+if [ -f a.out ]; then
+	echo "	fontsrv dependencies found."
+	echo "FONTSRV=fontsrv" >>$PLAN9/config
+else
+	echo "	fontsrv dependencies not found."
+	echo "FONTSRV=" >>$PLAN9/config
+	rm -f bin/fontsrv
 fi
+rm -f a.out
+
 
 if [ -f LOCAL.config ]; then
 	echo Using LOCAL.config options:


### PR DESCRIPTION
Adding the paths for Xquartz include files allows fontsrv compilation on OSX
I've been using it for sometime without issues (Mavericks)
