### PR TITLE
Update for most recent FreeBSD

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -19,7 +19,7 @@ case "$tag" in
 	5.2.*)
 		extralibs="$extralibs -lkse"
 		;;
-	[5-9].*)
+	[5-9].*|10.*)
 		extralibs="$extralibs -lpthread"
 		;;
 	esac

--- a/bin/web
+++ b/bin/web
@@ -34,7 +34,7 @@ plumbunix()
 		$BROWSER -remote 'openURL('"$@"',new-tab)' ||
 		$BROWSER "$@"
 		;;
-	*google-chrome*|*chromium*)
+	*google-chrome*|*chromium*|*chrome*)
 		$BROWSER "$@"
 		;;
 	esac


### PR DESCRIPTION
A couple of trivial changes: First off, FreeBSD 10.\* should get the same linker treatment as 5-9. Second, the chromium port on FreeBSD installs the binary as 'chrome'.
