### PR TITLE
Add new ignore to quiet()

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -42,6 +42,7 @@ quiet()
 	ignore=$ignore'|use of C99 long long'
 	ignore=$ignore'|ISO C forbids conversion'
 	ignore=$ignore'|is deprecated'
+	ignore=$ignore'|are deprecated'
 	ignore=$ignore'|warn_unused_result'
 
 	grep -v '__p9l_autolib_' $1 |


### PR DESCRIPTION
When compiling a basic hello world, glibc 2.21-r1 makes gcc issue the following:
```
warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
```