### PR TITLE
acme: add -t option

### DIFF
--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -23,6 +23,10 @@ acme, win, awd \- interactive text windows
 .I mtpt
 ]
 [
+.B -t
+.I title
+]
+[
 .B -l
 .I file
 |
@@ -91,6 +95,9 @@ to mount itself at
 .IR mtpt .
 (Experimental.)
 .PP
+The
+.B -t
+option sets the window title (default is "acme").
 .SS Windows
 .I Acme
 windows are in two parts: a one-line

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -42,6 +42,8 @@ char		*fontnames[2] =
 	"/lib/font/bit/lucm/unicode.9.font"
 };
 
+char		*title = "acme";
+
 Command *command;
 
 void	shutdownthread(void*);
@@ -113,6 +115,11 @@ threadmain(int argc, char *argv[])
 	case 'r':
 		swapscrollbuttons = TRUE;
 		break;
+	case 't':
+		title = ARGF();
+		if(title == nil)
+			goto Usage;
+		break;
 	case 'W':
 		winsize = ARGF();
 		if(winsize == nil)
@@ -120,7 +127,7 @@ threadmain(int argc, char *argv[])
 		break;
 	default:
 	Usage:
-		fprint(2, "usage: acme -a -c ncol -f fontname -F fixedwidthfontname -l loadfile -W winsize\n");
+		fprint(2, "usage: acme -a -c ncol -f fontname -F fixedwidthfontname -l loadfile -t title -W winsize\n");
 		threadexitsall("usage");
 	}ARGEND
 
@@ -157,12 +164,12 @@ threadmain(int argc, char *argv[])
 	getwd(wdir, sizeof wdir);
 
 /*
-	if(geninitdraw(nil, derror, fontnames[0], "acme", nil, Refnone) < 0){
+	if(geninitdraw(nil, derror, fontnames[0], title, nil, Refnone) < 0){
 		fprint(2, "acme: can't open display: %r\n");
 		threadexitsall("geninitdraw");
 	}
 */
-	if(initdraw(derror, fontnames[0], "acme") < 0){
+	if(initdraw(derror, fontnames[0], title) < 0){
 		fprint(2, "acme: can't open display: %r\n");
 		threadexitsall("initdraw");
 	}


### PR DESCRIPTION
to set the acme window title by using the given argument as the label
for initdraw.

When running multiple instances of acme in parallel¹ on Mac OS X the acme windows
show up in the Task Switcher (`⌘-TAB`) as Glenda with "devdraw" below and the application badge reads "acme".

Setting the application badge via the new command line option `-t` greatly helps in distinguishing which
acme window is the desired one to switch to (see attached screenshot below).

<img width="574" alt="acme_title_example" src="https://cloud.githubusercontent.com/assets/16507/12719295/7ad2d7ea-c8f4-11e5-83da-072bab1170be.png">

¹ as suggested by Jacek Masiulaniec in the comments to [A Tour of Acme](http://research.swtch.com/acme).