### PR TITLE
Tweaks to acme mail

### DIFF
--- a/src/cmd/acme/mail/html.c
+++ b/src/cmd/acme/mail/html.c
@@ -23,10 +23,11 @@ formathtml(char *body, int *np)
 	e->p[1] = p[1];
 	e->q[0] = q[0];
 	e->q[1] = q[1];
-	e->argv = emalloc(3*sizeof(char*));
+	e->argv = emalloc(4*sizeof(char*));
 	e->argv[0] = estrdup("htmlfmt");
 	e->argv[1] = estrdup("-cutf-8");
-	e->argv[2] = nil;
+	e->argv[2] = estrdup("-a");
+	e->argv[3] = nil;
 	e->prog = "htmlfmt";
 	sync = chancreate(sizeof(int), 0);
 	e->sync = sync;

--- a/src/cmd/acme/mail/mesg.c
+++ b/src/cmd/acme/mail/mesg.c
@@ -463,6 +463,11 @@ mesgmenu(Window *w, Message *mbox)
 	winopenbody(w, OWRITE);
 	mesgmenu0(w, mbox, mbox->name, "", 0, w->body, 0, !shortmenu);
 	winclosebody(w);
+	/* make sure dot is visible */
+	winsetaddr(w, "0", 1);
+	ctlprint(w->ctl, "dot=addr\n");
+	ctlprint(w->ctl, "show\n");
+
 }
 
 /* one new message has arrived, as mbox->tail */
@@ -1346,6 +1351,10 @@ mesgopen(Message *mbox, char *dir, char *s, Message *mesg, int plumbed, char *di
 		/* sleep(100); */
 		winclean(m->w);
 		m->opened = 1;
+		/* make sure dot is visible */
+		winsetaddr(m->w, "0", 1);
+		ctlprint(m->w->ctl, "dot=addr\n");
+		ctlprint(m->w->ctl, "show\n");
 		if(ndirelem == 1){
 			free(u);
 			return 1;


### PR DESCRIPTION
Despite what the commit message says, this only modifies Acme. It does 2 things:

1. Makes htmlfmt include URLs for easy plumbability
2. When you open the mbox or a mail message, it moves your view back to the top of the buffer (previous behavior left it at the bottom which was annoying)