### PR TITLE
fix build on osx

### DIFF
--- a/src/cmd/devdraw/cocoa-screen.m
+++ b/src/cmd/devdraw/cocoa-screen.m
@@ -28,29 +28,31 @@
 #include "bigarrow.h"
 #include "glendapng.h"
 
+/* these #defines break the OSX build, at least on 10.11.6 El Capitan.
 // Use non-deprecated names.
-#define NSKeyDown NSEventTypeKeyDown
-#define NSAlternateKeyMask NSEventModifierFlagOption
-#define NSCommandKeyMask NSEventModifierFlagCommand
-#define NSResizableWindowMask NSWindowStyleMaskResizable
-#define NSLeftMouseDown NSEventTypeLeftMouseDown
-#define NSLeftMouseUp NSEventTypeLeftMouseUp
-#define NSRightMouseDown NSEventTypeRightMouseDown
-#define NSRightMouseUp NSEventTypeRightMouseUp
-#define NSOtherMouseDown NSEventTypeOtherMouseDown
-#define NSOtherMouseUp NSEventTypeOtherMouseUp
-#define NSScrollWheel NSEventTypeScrollWheel
-#define NSMouseMoved NSEventTypeMouseMoved
-#define NSLeftMouseDragged NSEventTypeLeftMouseDragged
-#define NSRightMouseDragged NSEventTypeRightMouseDragged
-#define NSOtherMouseDragged NSEventTypeOtherMouseDragged
-#define NSCompositeCopy NSCompositingOperationCopy
-#define NSCompositeSourceIn NSCompositingOperationSourceIn
-#define NSFlagsChanged NSEventTypeFlagsChanged
-#define NSTitledWindowMask NSWindowStyleMaskTitled
-#define NSClosableWindowMask NSWindowStyleMaskClosable
-#define NSMiniaturizableWindowMask NSWindowStyleMaskMiniaturizable
-#define NSBorderlessWindowMask NSWindowStyleMaskBorderless
+define NSKeyDown NSEventTypeKeyDown
+define NSAlternateKeyMask NSEventModifierFlagOption
+define NSCommandKeyMask NSEventModifierFlagCommand
+define NSResizableWindowMask NSWindowStyleMaskResizable
+define NSLeftMouseDown NSEventTypeLeftMouseDown
+define NSLeftMouseUp NSEventTypeLeftMouseUp
+define NSRightMouseDown NSEventTypeRightMouseDown
+define NSRightMouseUp NSEventTypeRightMouseUp
+define NSOtherMouseDown NSEventTypeOtherMouseDown
+define NSOtherMouseUp NSEventTypeOtherMouseUp
+define NSScrollWheel NSEventTypeScrollWheel
+define NSMouseMoved NSEventTypeMouseMoved
+define NSLeftMouseDragged NSEventTypeLeftMouseDragged
+define NSRightMouseDragged NSEventTypeRightMouseDragged
+define NSOtherMouseDragged NSEventTypeOtherMouseDragged
+define NSCompositeCopy NSCompositingOperationCopy
+define NSCompositeSourceIn NSCompositingOperationSourceIn
+define NSFlagsChanged NSEventTypeFlagsChanged
+define NSTitledWindowMask NSWindowStyleMaskTitled
+define NSClosableWindowMask NSWindowStyleMaskClosable
+define NSMiniaturizableWindowMask NSWindowStyleMaskMiniaturizable
+define NSBorderlessWindowMask NSWindowStyleMaskBorderless
+*/
 
 AUTOFRAMEWORK(Cocoa)
 


### PR DESCRIPTION
Build is broken on El Capital (OSX 10.11.6/amd64) with clang 7.3.0. Commenting out
these renames fixes the build.

Fixes https://github.com/9fans/plan9port/issues/66