### PR TITLE
devdraw: Fix build on macOS<10.12

### DIFF
--- a/src/cmd/devdraw/cocoa-screen.m
+++ b/src/cmd/devdraw/cocoa-screen.m
@@ -29,6 +29,7 @@
 #include "glendapng.h"
 
 // Use non-deprecated names.
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 #define NSKeyDown NSEventTypeKeyDown
 #define NSAlternateKeyMask NSEventModifierFlagOption
 #define NSCommandKeyMask NSEventModifierFlagCommand
@@ -51,6 +52,7 @@
 #define NSClosableWindowMask NSWindowStyleMaskClosable
 #define NSMiniaturizableWindowMask NSWindowStyleMaskMiniaturizable
 #define NSBorderlessWindowMask NSWindowStyleMaskBorderless
+#endif
 
 AUTOFRAMEWORK(Cocoa)
 


### PR DESCRIPTION
After making the build on macOS silent on
commit 310ae03327a815e721166b64aa3af27b1cc8c2ff it broke
the build on macOS lesser than 10.12 (Sierra). See issue #66.

This commit conditionally checks the version the of the SDK
before using the defined values for silent build.

Signed-off-by: Rudá Moura <ruda.moura@gmail.com>