### PR TITLE
build: Support Arch Linux on arm64 (aarch64)

### DIFF
--- a/dist/buildmk
+++ b/dist/buildmk
@@ -17,5 +17,6 @@ OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
 	s;.*ppc.*;power;g;
 	s;.*alpha.*;alpha;g;
 	s;.*sun4u.*;sun4u;g;
+	s;.*aarch64.*;arm64;g;
 '` export OBJTYPE
 sh -x mkmk.sh


### PR DESCRIPTION
Arch Linux uses aarch64 as architecture/machine symbol when running on ARMv7 AArch64.

$ uname -svm
Linux #1 SMP PREEMPT Sat Jul 29 13:44:05 CEST 2017 aarch64
