### PR TITLE
Remove WSYSTYPE safeguard in mkriorules.sh

### DIFF
--- a/src/cmd/rio/mkriorules.sh
+++ b/src/cmd/rio/mkriorules.sh
@@ -1,6 +1,1 @@
-if [ "x$WSYSTYPE" != xx11 ]; then
-	echo 'all install clean nuke:Q:'
-	echo '	#'
-	exit 0
-fi
 cat $PLAN9/src/mkmany


### PR DESCRIPTION
The WSYSTYPE safeguard causes rio to fail to build on macOS & previous versions, both when running the install script and running 'mk' manually. It provides no verbose, and the user is left to debug on their own. I'm not sure what the original use of the safeguard was, but I can't think of one, and it seems a little outdated.

I left mkriorules.sh (which now only contains a cat line) in the mkfile, as I figured it may have other uses.