### PR TITLE
acme: allow file names containing spaces

### DIFF
--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -130,6 +130,12 @@ threadmain(int argc, char *argv[])
 	quotefmtinstall();
 	fmtinstall('t', timefmt);
 
+	p = getenv("replacespace");
+	replacespace = L'␣';
+	if(p != nil){
+		chartorune(&replacespace, p);
+	}
+
 	cputype = getenv("cputype");
 	objtype = getenv("objtype");
 	home = getenv("HOME");

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -553,6 +553,7 @@ int			messagesize;		/* negotiated in 9P version setup */
 int			globalautoindent;
 int			dodollarsigns;
 char*		mtpt;
+Rune		replacespace;
 
 enum
 {

--- a/src/cmd/acme/exec.c
+++ b/src/cmd/acme/exec.c
@@ -148,7 +148,7 @@ lookup(Rune *r, int n)
 int
 isexecc(int c)
 {
-	if(isfilec(c))
+	if(isfilec(c) && c != ' ')
 		return 1;
 	return c=='<' || c=='|' || c=='>';
 }
@@ -499,7 +499,9 @@ getname(Text *t, Text *argt, Rune *arg, int narg, int isput)
 	if(promote){
 		n = narg;
 		if(n <= 0){
+			runetr(t->file->name, t->file->nname, replacespace, ' ');
 			s = runetobyte(t->file->name, t->file->nname);
+			runetr(t->file->name, t->file->nname, ' ', replacespace);
 			return s;
 		}
 		/* prefix with directory name if necessary */
@@ -526,6 +528,7 @@ getname(Text *t, Text *argt, Rune *arg, int narg, int isput)
 			runemove(r, arg, n);
 		}
 	}
+	runetr(r, n, replacespace, ' ');
 	s = runetobyte(r, n);
 	free(r);
 	if(strlen(s) == 0){
@@ -648,7 +651,9 @@ putfile(File *f, int q0, int q1, Rune *namer, int nname)
 	int isapp;
 
 	w = f->curtext->w;
+	runetr(namer, nname, replacespace, ' ');
 	name = runetobyte(namer, nname);
+	runetr(namer, nname, ' ', replacespace);
 	d = dirstat(name);
 	if(d!=nil && runeeq(namer, nname, f->name, f->nname)){
 		/* f->mtime+1 because when talking over NFS it's often off by a second */

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -93,6 +93,7 @@ Rune*	findbl(Rune*, int, int*);
 char*	edittext(Window*, int, Rune*, int);
 void		flushwarnings(void);
 void		startplumbing(void);
+void		runetr(Rune *, int, Rune, Rune);
 
 Runestr	runestr(Rune*, uint);
 Range range(int, int);

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -377,7 +377,7 @@ search(Text *ct, Rune *r, uint n)
 int
 isfilec(Rune r)
 {
-	static Rune Lx[] = { '.', '-', '+', '/', ':', 0 };
+	static Rune Lx[] = { '.', '-', '+', '/', ':', ' ', 0 };
 	if(isalnum(r))
 		return TRUE;
 	if(runestrchr(Lx, r))
@@ -392,6 +392,7 @@ cleanrname(Runestr rs)
 	char *s;
 	int nb, nulls;
 
+	runetr(rs.r, rs.nr, replacespace, ' ');
 	s = runetobyte(rs.r, rs.nr);
 	cleanname(s);
 	cvttorunes(s, strlen(s), rs.r, &nb, &rs.nr, &nulls);
@@ -602,6 +603,7 @@ expandfile(Text *t, uint q0, uint q1, Expand *e)
 		nname = rs.nr;
 	}
 	e->bname = runetobyte(r, nname);
+	runetr(r, nname, ' ', replacespace);
 	/* if it's already a window name, it's a file */
 	w = lookfile(r, nname);
 	if(w != nil)

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -492,3 +492,15 @@ makenewwindow(Text *t)
 		colgrow(w->col, w, 1);
 	return w;
 }
+
+void
+runetr(Rune *r, int nr, Rune from, Rune to)
+{
+	int i;
+	if (from == to)
+		return;
+
+	for (i = 0; i < nr; i++)
+		if (r[i] == from)
+			r[i] = to;
+}


### PR DESCRIPTION
Permit Acme to successfully edit files whose paths contain spaces by
reversibly substituting a different rune for the offending space. The
substitute rune can be controlled with the replacespace environment
variable and defaults to '␣'.