### PR TITLE
fontsrv: increase x11 font height scale

### DIFF
--- a/src/cmd/fontsrv/x11.c
+++ b/src/cmd/fontsrv/x11.c
@@ -80,7 +80,7 @@ load(XFont *f)
 	}
 
 	f->unit = face->units_per_EM;
-	f->height = (int)((face->ascender - face->descender) * 1.2);
+	f->height = (int)((face->ascender - face->descender) * 1.35);
 	f->originy = face->descender; // bbox.yMin (or descender)  is negative, becase the baseline is y-coord 0
 
 	for(charcode=FT_Get_First_Char(face, &glyph_index); glyph_index != 0;


### PR DESCRIPTION
The comparison between the patched and current versions can be seem in the images below (left is gnome-terminal, right is 9term):

**Current**
![current-liberationmono](https://user-images.githubusercontent.com/8078684/31057692-89cbc650-a6bd-11e7-9319-f33027663f9b.png)

**Patched**
![patched-freemono](https://user-images.githubusercontent.com/8078684/31057693-89cc72da-a6bd-11e7-9a4f-10a793a4bffe.png)
![patched-liberationmono](https://user-images.githubusercontent.com/8078684/31057694-89cd4e3a-a6bd-11e7-9b6d-e1c7a8b6ece0.png)
