### PR TITLE
Support Mac IME

### DIFF
--- a/src/cmd/devdraw/cocoa-screen.m
+++ b/src/cmd/devdraw/cocoa-screen.m
@@ -115,7 +115,7 @@ threadmain(int argc, char **argv)
 	default:
 		usage();
 	}ARGEND
-	
+
 	setprocname(argv0);
 
 	if (envvar = getenv("devdrawretina"))
@@ -298,7 +298,12 @@ attachscreen(char *label, char *winsize)
 }
 
 @interface appwin : NSWindow @end
-@interface contentview : NSView @end
+@interface contentview : NSView <NSTextInputClient> {
+  NSRange _markedRange;
+  NSRange _selectedRange;
+  NSEvent *_keydownEvent;
+}
+@end
 
 @implementation appwin
 - (NSTimeInterval)animationResizeTime:(NSRect)r
@@ -336,14 +341,14 @@ attachscreen(char *label, char *winsize)
 {
 	NSPasteboard *b;
 	NSDragOperation op;
-	
+
 	op = [arg draggingSourceOperationMask];
 	b = [arg draggingPasteboard];
-	
+
 	if([[b types] containsObject:NSFilenamesPboardType])
 	if(op&NSDragOperationLink)
 		return NSDragOperationLink;
-	
+
 	return NSDragOperationNone;
 }
 
@@ -422,7 +427,7 @@ makewin(char *s)
 #endif
 	[w setContentMinSize:NSMakeSize(128,128)];
 
-	[w registerForDraggedTypes:[NSArray arrayWithObjects: 
+	[w registerForDraggedTypes:[NSArray arrayWithObjects:
 		NSFilenamesPboardType, nil]];
 
 	win.ofs[0] = w;
@@ -474,7 +479,7 @@ initimg(void)
 	[win.img setSize: ptsize];
 	win.topixelscale = size.width / ptsize.width;
 	win.topointscale = 1.0f / win.topixelscale;
-	
+
 	// NOTE: This is not really the display DPI.
 	// On retina, topixelscale is 2; otherwise it is 1.
 	// This formula gives us 220 for retina, 110 otherwise.
@@ -738,7 +743,134 @@ static void getmouse(NSEvent*);
 static void gettouch(NSEvent*, int);
 static void updatecursor(void);
 
+static int keycvt[] =
+{
+	[QZ_IBOOK_ENTER] '\n',
+	[QZ_RETURN] '\n',
+	[QZ_ESCAPE] 27,
+	[QZ_BACKSPACE] '\b',
+	[QZ_LALT] Kalt,
+	[QZ_LCTRL] Kctl,
+	[QZ_LSHIFT] Kshift,
+	[QZ_F1] KF+1,
+	[QZ_F2] KF+2,
+	[QZ_F3] KF+3,
+	[QZ_F4] KF+4,
+	[QZ_F5] KF+5,
+	[QZ_F6] KF+6,
+	[QZ_F7] KF+7,
+	[QZ_F8] KF+8,
+	[QZ_F9] KF+9,
+	[QZ_F10] KF+10,
+	[QZ_F11] KF+11,
+	[QZ_F12] KF+12,
+	[QZ_INSERT] Kins,
+	[QZ_DELETE] 0x7F,
+	[QZ_HOME] Khome,
+	[QZ_END] Kend,
+	[QZ_KP_PLUS] '+',
+	[QZ_KP_MINUS] '-',
+	[QZ_TAB] '\t',
+	[QZ_PAGEUP] Kpgup,
+	[QZ_PAGEDOWN] Kpgdown,
+	[QZ_UP] Kup,
+	[QZ_DOWN] Kdown,
+	[QZ_LEFT] Kleft,
+	[QZ_RIGHT] Kright,
+	[QZ_KP_MULTIPLY] '*',
+	[QZ_KP_DIVIDE] '/',
+	[QZ_KP_ENTER] '\n',
+	[QZ_KP_PERIOD] '.',
+	[QZ_KP0] '0',
+	[QZ_KP1] '1',
+	[QZ_KP2] '2',
+	[QZ_KP3] '3',
+	[QZ_KP4] '4',
+	[QZ_KP5] '5',
+	[QZ_KP6] '6',
+	[QZ_KP7] '7',
+	[QZ_KP8] '8',
+	[QZ_KP9] '9',
+};
+static void interpretdeadkey(NSEvent *e);
+
+
 @implementation contentview
+static const NSRange kEmptyRange = {NSNotFound, 0};
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+- (void) removeMarkedText {
+  if (_markedRange.location != NSNotFound) {
+  	//Remove marked range by sending backspaces.
+    for(int i = 0; i < _markedRange.length; i++) {
+      keystroke('\b');
+    }
+    _markedRange = _selectedRange = kEmptyRange;
+  }
+}
+
+- (void) replaceCharactersInRange: (NSRange) aRange
+                         withText: (id) aString
+                   effectiveRange: (NSRangePointer) effectiveRange
+{
+  NSRange replacementRange = aRange;
+  int len = 0;
+  if ([aString isKindOfClass: [NSAttributedString class]]) {
+    len = [[aString string] length];
+  } else {
+    len = [aString length];
+  }
+  if (replacementRange.location == NSNotFound) {
+    replacementRange.location = 1;
+    replacementRange.length = 0;
+  }
+
+  //Remove old translation by sending backspaces.
+  for(int i = 0; i < aRange.length; i++) {
+    keystroke('\b');
+  }
+
+  //Send new translation.
+  if ([aString isKindOfClass: [NSAttributedString class]]) {
+    for(int i=0; i<len; i++) {
+      int c = [[aString string] characterAtIndex:i];
+      keystroke(c);
+    }
+  } else {
+    for(int i=0; i<len; i++) {
+      int c = [aString characterAtIndex:i];
+      keystroke(c);
+    }
+  }
+
+  if (effectiveRange != NULL) {
+    *effectiveRange = NSMakeRange(replacementRange.location, [aString length]);
+  }
+}
+
+/**
+ * If there is no marked text, the current selection is replaced.
+ * If there is no selection, the string is inserted at the insertion point.
+ *
+ * @param replacementRange The range to replace, computed from
+ *                         the beginning of the marked text.
+ */
+- (NSRange) replacementMarkedRange: (NSRange) replacementRange {
+  NSRange markedRange = _markedRange;
+
+  if (markedRange.location == NSNotFound) markedRange = _selectedRange;
+  if (replacementRange.location != NSNotFound) {
+    NSRange newRange = markedRange;
+    newRange.location += replacementRange.location;
+    newRange.length += replacementRange.length;
+    if (NSMaxRange(newRange) <= NSMaxRange(markedRange)) {
+      markedRange = newRange;
+    }
+  }
+
+  return markedRange;
+}
 /*
  * "drawRect" is called each time Cocoa needs an
  * image, and each time we call "display".  It is
@@ -775,6 +907,7 @@ static void updatecursor(void);
 	[super initWithFrame:r];
 	[self setAcceptsTouchEvents:YES];
 	[self setHidden:YES];		/* to avoid early "drawRect" call */
+        _selectedRange = _markedRange = kEmptyRange;
 	return self;
 }
 - (void)setHidden:(BOOL)set
@@ -786,7 +919,12 @@ static void updatecursor(void);
 - (void)cursorUpdate:(NSEvent*)e{ updatecursor();}
 
 - (void)mouseMoved:(NSEvent*)e{ getmouse(e);}
-- (void)mouseDown:(NSEvent*)e{ getmouse(e);}
+- (void)mouseDown:(NSEvent*)e{
+  _selectedRange = kEmptyRange;
+  [self unmarkText];
+  [self.inputContext discardMarkedText];
+  getmouse(e);
+}
 - (void)mouseDragged:(NSEvent*)e{ getmouse(e);}
 - (void)mouseUp:(NSEvent*)e{ getmouse(e);}
 - (void)otherMouseDown:(NSEvent*)e{ getmouse(e);}
@@ -797,7 +935,150 @@ static void updatecursor(void);
 - (void)rightMouseUp:(NSEvent*)e{ getmouse(e);}
 - (void)scrollWheel:(NSEvent*)e{ getmouse(e);}
 
-- (void)keyDown:(NSEvent*)e{ getkeyboard(e);}
+- (void)doCommandBySelector:(SEL)aSelector {
+  LOG(@"Do command by selector: %@", NSStringFromSelector(aSelector));
+  NSString *s;
+  char c;
+  int k, m;
+  uint code;
+  m = [_keydownEvent modifierFlags];
+  switch([_keydownEvent type]) {
+    case NSKeyDown:
+      s = [_keydownEvent characters];
+      c = [s UTF8String][0];
+      if(m & NSCommandKeyMask){
+        if(' '<=c && c<='~')
+          keystroke(Kcmd+c);
+        break;
+      }
+      k = c;
+      code = [_keydownEvent keyCode];
+      if(code<nelem(keycvt) && keycvt[code]) {
+        k = keycvt[code];
+      }
+      if(k==0)
+        break;
+      if(k>0) {
+        keystroke(k);
+      } else {
+        LOG(@"k < 0: %d, keystroke: %c", k, [s characterAtIndex: 0]);
+        //[self interpretKeyEvents: [NSArray arrayWithObject: e]];
+        keystroke([s characterAtIndex:0]);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+
+- (void)keyDown:(NSEvent*)e{
+  LOG(@"keyDown called");
+  switch([e type]) {
+    case NSKeyDown:
+      _keydownEvent = e;
+	  BOOL inputMethodIsInserting = [self.inputContext handleEvent: e];
+      if (!inputMethodIsInserting && ![self hasMarkedText])
+	  	keystroke([e keyCode]);
+      break;
+    default:
+      break;
+  }
+}
+
+- (void) deleteBackward: (id) sender {
+  // const NSUInteger length = [_text length];
+  LOG(@"NSResponder deleteBackward");
+  keystroke('\b');
+}
+
+- (void) deleteForward: (id) sender {
+  LOG(@"NSResponder deleteForward");
+  keystroke(0x7f);
+}
+
+- (void) insertNewline: (id) sender {
+  LOG(@"NSResponder insertNewline");
+  keystroke('\n');
+}
+
+- (void) insertTab: (id) sender {
+  LOG(@"NSResponder insertTab");
+  keystroke('\t');
+}
+
+- (void) insertText: (id) aString
+   replacementRange: (NSRange) replacementRange
+{
+  int len = [(NSString *)aString length];
+  LOG(@"NSResponder insertText '%@'\tlen = %d replacementRange: %@", aString, len, NSStringFromRange(replacementRange));
+  [self removeMarkedText];
+  [self replaceCharactersInRange: replacementRange
+                        withText: aString
+                  effectiveRange: NULL];
+  [self setNeedsDisplay: YES];
+}
+
+- (void) setMarkedText: (id) aString
+         selectedRange: (NSRange) selectedRange
+      replacementRange: (NSRange) replacementRange
+{
+  NSRange effectiveRange;
+
+  LOG(@"setMarkedText: %@", NSStringFromRange(replacementRange));
+
+  [self replaceCharactersInRange: [self replacementMarkedRange: replacementRange]
+                        withText: aString
+                  effectiveRange: &effectiveRange];
+
+  if (selectedRange.location != NSNotFound) selectedRange.location += effectiveRange.location;
+  _selectedRange = selectedRange;
+  _markedRange = effectiveRange;
+  if ([aString length] == 0) [self removeMarkedText];
+  [self setNeedsDisplay: YES];
+}
+
+- (NSAttributedString *) attributedSubstringForProposedRange: (NSRange) aRange
+                                                 actualRange: (NSRangePointer) actualRange
+{
+  return [[[NSAttributedString alloc] init] autorelease];
+}
+
+- (NSUInteger) characterIndexForPoint: (NSPoint) thePoint {
+  return 0;
+}
+
+- (NSRect) firstRectForCharacterRange: (NSRange) aRange
+                          actualRange: (NSRangePointer) actualRange
+{
+	NSRect viewRect = [WIN convertRectToScreen:self.frame];
+	return NSMakeRect(NSMinX(viewRect), NSMinY(viewRect), 0, 0);
+}
+
+- (NSAttributedString *) attributedString {
+	return NULL;
+}
+
+- (void) unmarkText {
+    _markedRange = NSMakeRange(NSNotFound, 0);
+}
+
+- (BOOL) hasMarkedText {
+    return _markedRange.location != NSNotFound;
+}
+
+- (NSRange) markedRange {
+  return _markedRange;
+}
+
+- (NSRange) selectedRange {
+  return _selectedRange;
+}
+
+- (NSArray *) validAttributesForMarkedText {
+    return [NSArray array];
+}
+
 - (void)flagsChanged:(NSEvent*)e{ getkeyboard(e);}
 
 - (void)magnifyWithEvent:(NSEvent*)e{ getgesture(e);}
@@ -819,56 +1100,6 @@ static void updatecursor(void);
 	gettouch(e, NSTouchPhaseCancelled);
 }
 @end
-
-static int keycvt[] =
-{
-	[QZ_IBOOK_ENTER]= '\n',
-	[QZ_RETURN]= '\n',
-	[QZ_ESCAPE]= 27,
-	[QZ_BACKSPACE]= '\b',
-	[QZ_LALT]= Kalt,
-	[QZ_LCTRL]= Kctl,
-	[QZ_LSHIFT]= Kshift,
-	[QZ_F1]= KF+1,
-	[QZ_F2]= KF+2,
-	[QZ_F3]= KF+3,
-	[QZ_F4]= KF+4,
-	[QZ_F5]= KF+5,
-	[QZ_F6]= KF+6,
-	[QZ_F7]= KF+7,
-	[QZ_F8]= KF+8,
-	[QZ_F9]= KF+9,
-	[QZ_F10]= KF+10,
-	[QZ_F11]= KF+11,
-	[QZ_F12]= KF+12,
-	[QZ_INSERT]= Kins,
-	[QZ_DELETE]= 0x7F,
-	[QZ_HOME]= Khome,
-	[QZ_END]= Kend,
-	[QZ_KP_PLUS]= '+',
-	[QZ_KP_MINUS]= '-',
-	[QZ_TAB]= '\t',
-	[QZ_PAGEUP]= Kpgup,
-	[QZ_PAGEDOWN]= Kpgdown,
-	[QZ_UP]= Kup,
-	[QZ_DOWN]= Kdown,
-	[QZ_LEFT]= Kleft,
-	[QZ_RIGHT]= Kright,
-	[QZ_KP_MULTIPLY]= '*',
-	[QZ_KP_DIVIDE]= '/',
-	[QZ_KP_ENTER]= '\n',
-	[QZ_KP_PERIOD]= '.',
-	[QZ_KP0]= '0',
-	[QZ_KP1]= '1',
-	[QZ_KP2]= '2',
-	[QZ_KP3]= '3',
-	[QZ_KP4]= '4',
-	[QZ_KP5]= '5',
-	[QZ_KP6]= '6',
-	[QZ_KP7]= '7',
-	[QZ_KP8]= '8',
-	[QZ_KP9]= '9',
-};
 
 @interface apptext : NSTextView @end
 
@@ -1226,10 +1457,10 @@ togglefs(void)
 
 #if OSX_VERSION >= 100700
 	NSScreen *s, *s0;
-	
+
 	s = [WIN screen];
 	s0 = [[NSScreen screens] objectAtIndex:0];
-	
+
 	if((s==s0 && useoldfullscreen==0) || win.isnfs) {
 		[WIN toggleFullScreen:nil];
 		return;
@@ -1357,7 +1588,7 @@ getsnarf(void)
 	qunlock(&snarfl);
 
 	if(s)
-		return strdup((char*)[s UTF8String]);		
+		return strdup((char*)[s UTF8String]);
 	else
 		return nil;
 }
@@ -1545,7 +1776,7 @@ static void
 setprocname(const char *s)
 {
   CFStringRef process_name;
-  
+
   process_name = CFStringCreateWithBytes(nil, (uchar*)s, strlen(s), kCFStringEncodingUTF8, false);
 
   // Adapted from Chrome's mac_util.mm.

--- a/src/cmd/samterm/main.c
+++ b/src/cmd/samterm/main.c
@@ -512,10 +512,11 @@ nontypingkey(int c)
 	case PAGEUP:
 	case RIGHTARROW:
 	case SCROLLKEY:
+        case CUT:
+        case COPY:
+        case PASTE:
 		return 1;
 	}
-	if(c >= Kcmd)
-		return 1;
 	return 0;
 }
 


### PR DESCRIPTION
<img width="682" alt="2017-11-04 10 37 30" src="https://user-images.githubusercontent.com/236528/32401107-3926a7e8-c14c-11e7-986f-1dfbd00f85ce.png">

Roughly implemented Mac IME support to devdraw:

- based on [tiancaiamao/devdraw](https://github.com/tiancaiamao/devdraw) 's Chinese IME support, and improve IME handling 
- Implement NSTextInputClient on devdraw's contentView.
- Change keyevent buffer to linked list from ring-buffer to avoid ring-buffer overflow.

Currently supported inline translation, but it needs patching to some application(sam).
~~So I'm thinking about displaying temporary input buffer on devdraw layer and send text to application after user submitted text.~~

- Acme works fine (with my local Japanese IME) without any modification
- Sam works with little modification to strict check Cut, Paste, Copy Kcmd
<img width="761" alt="2017-11-04 10 38 59" src="https://user-images.githubusercontent.com/236528/32401133-9965b338-c14c-11e7-8c02-ead86005d645.png">

- 9term works with cooked mode.

<img width="691" alt="2017-11-04 10 41 33" src="https://user-images.githubusercontent.com/236528/32401143-bea07d9a-c14c-11e7-9226-20ce4dd47c32.png">
