### PR TITLE
skip only the surrogate pairs

### DIFF
--- a/src/cmd/fontsrv/osx.c
+++ b/src/cmd/fontsrv/osx.c
@@ -30,7 +30,7 @@ mapUnicode(char *name, int i)
 {
 	int j;
 
-	if(0xd800 <= i && i < 0xe0000) // surrogate pairs, will crash OS X libraries!
+	if(0xd800 <= i && i < 0xe000) // surrogate pairs, will crash OS X libraries!
 		return 0xfffd;
 	for(j=0; j<nelem(skipquotemap); j++) {
 		if(strstr(name, skipquotemap[j]))


### PR DESCRIPTION
fontsrv wasn't rendering fontawesome icons, which uses the private use area around 0xf000.

see https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates