### PR TITLE
Use proper type for storing ulimit values.

### DIFF
--- a/src/cmd/rc/unixcrap.c
+++ b/src/cmd/rc/unixcrap.c
@@ -58,7 +58,8 @@ eusage(void)
 void
 execulimit(void)
 {
-	int fd, n, argc, sethard, setsoft, limit;
+	rlim_t n;
+	int fd, argc, sethard, setsoft, limit;
 	int flag[256];
 	char **argv, **oargv, *p;
 	char *argv0;
@@ -118,10 +119,10 @@ execulimit(void)
 		for(p=eargs; *p; p++){
 			getrlimit(rlx[p-eargs], &rl);
 			n = flag['H'] ? rl.rlim_max : rl.rlim_cur;
-			if(n == -1)
+			if(n == RLIM_INFINITY)
 				fprint(fd, "ulimit -%c unlimited\n", *p);
 			else
-				fprint(fd, "ulimit -%c %d\n", *p, n);
+				fprint(fd, "ulimit -%c %llud\n", *p, (uvlong)n);
 		}
 		goto out;
 	}
@@ -132,10 +133,10 @@ execulimit(void)
 			switch(limit){
 			case Notset:
 				n = flag['H'] ? rl.rlim_max : rl.rlim_cur;
-				if(n == -1)
+				if(n == RLIM_INFINITY)
 					fprint(fd, "ulimit -%c unlimited\n", *p);
 				else
-					fprint(fd, "ulimit -%c %d\n", *p, n);
+					fprint(fd, "ulimit -%c %llud\n", *p, (uvlong)n);
 				break;
 			case Hard:
 				n = rl.rlim_max;
@@ -144,7 +145,7 @@ execulimit(void)
 				n = rl.rlim_cur;
 				goto set;
 			case Unlimited:
-				n = -1;
+				n = RLIM_INFINITY;
 				goto set;
 			default:
 				n = limit;


### PR DESCRIPTION
rc on amd64 stores ulimit values as 32-bit int, but the limits on
OpenBSD amd64 can exceed 2^31, so "ulimit -a" shows some values as
negative. This is a problem when I want to increase my ulimit but
the hard ulimit values are printed as negative.