### PR TITLE
mount: Check that osxfuse kext is loaded

### DIFF
--- a/bin/mount
+++ b/bin/mount
@@ -22,6 +22,7 @@ case Darwin
 	if(sysctl fuse.version >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl macfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl osxfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
+	   kextstat -l |9 grep -si 'com.github.osxfuse.filesystems.osxfuse' ||
 	   test -d /System/Library/Extensions/fusefs.kext ||
 	   test -d /Library/Filesystems/osxfusefs.fs/Support/osxfusefs.kext ||
 	   test -d /Library/Filesystems/fusefs.fs/Support/fusefs.kext)


### PR DESCRIPTION
Mount(1) currently checks whether FUSE is present on macOS by looking
for sysctl info or for kernel extensions (kexts) present at certain paths.
Current osxfuse ships with four different versions of its kext for
different versions of macOS.

The problems with this approach are that
1) the kexts are at a different path than the one mount checks
2) the FUSE kext may not have been loaded

This change inserts a check whether the osxfuse kext has been loaded
into mount.  We run kextstat(8) to generate a list of loaded kexts, then
grep for the bundle identifier used for the osxfuse kext.

The `-l` flag to kextstat lets it print only the list of kexts, omitting
a table header it would otherwise print.
Kextstat also understands a `-b` flag to filter by bundle identifier,
but its exit status does not reflect whether it found any matching kexts
so we would still need to grep for something like `.`.

The `-i` flag to grep is not strictly required here since the case of
the osxfuse kext bundle id is well known.

The change leaves the filesystem checks for kexts in place for
compatibility reasons.  This means that unloaded kexts would still be
detected, changing this would require determining the kext bundle ids of
older FUSE libraries.

diff --git c/bin/mount i/bin/mount
index 79b974f7..5af023da 100755
--- c/bin/mount
+++ i/bin/mount
@@ -22,6 +22,7 @@ case Darwin
 	if(sysctl fuse.version >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl macfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl osxfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
+	   kextstat -l |9 grep -si 'com.github.osxfuse.filesystems.osxfuse' ||
 	   test -d /System/Library/Extensions/fusefs.kext ||
 	   test -d /Library/Filesystems/osxfusefs.fs/Support/osxfusefs.kext ||
 	   test -d /Library/Filesystems/fusefs.fs/Support/fusefs.kext)

Change-Id: I997f270f72cf6d5da3423a4584a01c1a5024460c