### PR TITLE
mount: Check current osxfuse kext location

### DIFF
--- a/bin/mount
+++ b/bin/mount
@@ -19,10 +19,12 @@ case FreeBSD
 		exec 9pfuse $1 $2
 	echo 'don''t know how to mount (no fuse)' >[1=2]
 case Darwin
+	version=`{sw_vers -productVersion|cut -d. -f1,2}
 	if(sysctl fuse.version >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl macfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   sysctl osxfuse.version.number >[2]/dev/null |9 grep -si 'fuse.version' ||
 	   test -d /System/Library/Extensions/fusefs.kext ||
+	   test -d /Library/Filesystems/osxfuse.fs/Contents/Extensions/$version/osxfuse.kext ||
 	   test -d /Library/Filesystems/osxfusefs.fs/Support/osxfusefs.kext ||
 	   test -d /Library/Filesystems/fusefs.fs/Support/fusefs.kext)
 		exec 9pfuse $1 $2


### PR DESCRIPTION
Current versions of osxfuse ship with multiple versions of its kernel
extension (kext) for differend versions of macOS.

Running mount(1) on macOS with a current version of osxfuse fails with
`don't know how to mount (no fuse)' since it fails to find the kext.
Running 9pfuse(4) directly works fine.

This change adds a check to mount(1) that determines:
1) which version of macOS we're running on
2) if there is an osxfuse kext available for this version of macOS