### PR TITLE
git: Ignore files created for astro(1) and scat(1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ bin/
 log/
 dict/
 postscript/font/
+sky/here
+sky/*.scat
 *.orig
 config
 install.log


### PR DESCRIPTION
To use astro(1) and scat(1) one has to create sky/here and download
various catalogue files as detailed in sky/README.
This change marks those files as ignored by git so they don't clutter
its status messages.