### PR TITLE
9term.app: add $PLAN9/bin to $PATH if not already in $PATH

### DIFF
--- a/mac/9term.app/Contents/MacOS/9term
+++ b/mac/9term.app/Contents/MacOS/9term
@@ -2,4 +2,8 @@
 cd $HOME
 . ~/.bashrc
 PLAN9=${PLAN9:-/usr/local/plan9}
+if ! [[ :$PATH: =~ :$PLAN9/bin: ]]
+then
+	PATH=$PATH:$PLAN9/bin
+fi
 $PLAN9/bin/9term -W600x800 &


### PR DESCRIPTION
9term set *$PLAN9* if *$PLAN9* is not set. But *$PATH* is not set.
As a result, 9term exits with errors: 

> /usr/local/plan9/bin/9term: exec devdraw: No such file or directory
> /usr/local/plan9/bin/9term: initdraw: muxrpc: unexpected eof
