### PR TITLE
cmd/9term: Set TERM_PROGRAM to termprog

### DIFF
--- a/src/cmd/9term/rcstart.c
+++ b/src/cmd/9term/rcstart.c
@@ -87,6 +87,7 @@ rcstart(int argc, char **argv, int *pfd, int *tfd)
 	// Set $termprog to 9term or win for those who care about what kind of
 	// dumb terminal this is.
 	putenv("termprog", (char*)termprog);
+	putenv("TERM_PROGRAM", (char*)termprog);
 
 	pid = fork();
 	switch(pid){


### PR DESCRIPTION
TERM_PROGRAM is the customary way to identify which kind of terminal
emulator program one uses on macOS.
This change sets TERM_PROGRAM to termprog since both variables are used
for the same purpose.

For some examples, see:
https://apple.stackexchange.com/questions/42714/what-is-the-term-program-and-term-program-version-environment-variables-used-fo
https://github.com/jwilm/alacritty/issues/781
https://github.com/justinmk/vim-gtfo/issues/3
https://github.com/neovim/neovim/blob/f050aaabbb31b58ebac519a6f7014610f2b119f0/src/nvim/tui/tui.c#L206-L211