### PR TITLE
9pfuse: retries read(3) upon EINTR

### DIFF
--- a/src/cmd/9pfuse/fuse.c
+++ b/src/cmd/9pfuse/fuse.c
@@ -48,7 +48,6 @@ readfusemsg(void)
 	int n, nn;
 	
 	m = allocfusemsg();
-	errno = 0;
 	/*
 	 * The FUSE kernel device apparently guarantees
 	 * that this read will return exactly one message.
@@ -57,7 +56,11 @@ readfusemsg(void)
 	 * FUSE returns an ENODEV error, not EOF,
 	 * when the connection is unmounted.
 	 */
-	if((n = read(fusefd, m->buf, fusebufsize)) < 0){
+	do{
+		errno = 0;
+		n = read(fusefd, m->buf, fusebufsize);
+	}while(n < 0 && errno == EINTR);
+	if(n < 0){
 		if(errno != ENODEV)
 			sysfatal("readfusemsg: %r");
 	}


### PR DESCRIPTION
read(3) sometimes errors with EINTR on macOS over slow connections.
9pfuse(1) now retries read(3) instead of sysfatal(3)ing.