### PR TITLE
fontsrv: enlarge drawing buffer for subfonts on macOS

### DIFF
--- a/src/cmd/fontsrv/osx.c
+++ b/src/cmd/fontsrv/osx.c
@@ -104,6 +104,7 @@ static char *lines[] = {
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 	"abcdefghijklmnopqrstuvwxyz",
 	"g",
+	"┌┬┐├┼┤└┴┘│─",
 	"ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει.",
 	"私はガラスを食べられます。それは私を傷つけません。",
 	"Aš galiu valgyti stiklą ir jis manęs nežeidžia",
@@ -234,7 +235,7 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 	
 	
 	bbox = CTFontGetBoundingBox(font);
-	x = (int)(bbox.size.width + 0.99999999);
+	x = (int)(bbox.size.width*2 + 0.99999999);
 
 	fontheight(f, size, &height, &ascent);
 	y = height;
@@ -343,6 +344,7 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 	m1 = allocmemimage(Rect(0, 0, x, y), antialias ? GREY8 : GREY1);
 	memimagedraw(m1, m1->r, m, m->r.min, memopaque, ZP, S);
 	freememimage(m);
+	freememimage(mc);
 
 	sf->name = nil;
 	sf->n = hi+1 - lo;


### PR DESCRIPTION
Double the width returned by CTFontGetBoundingBox when drawing
Add box drawing characters for determining the line height
freememimage(1) for the character memimage

It should fix #146 #120, and likely #18.