### PR TITLE
TLS fix for upas/smtp

### DIFF
--- a/src/cmd/upas/smtp/smtp.c
+++ b/src/cmd/upas/smtp/smtp.c
@@ -467,6 +467,7 @@ hello(char *me, int encrypted)
 		}
 
 	ehlo = 1;
+	encrypted = 1;
   Again:
 	if(ehlo)
 		dBprint("EHLO %s\r\n", me);


### PR DESCRIPTION
This PR fixes the TLS functionality in `upas/smtp`. With these fixes, I am able to connect to TLS enabled email servers like Gmail and send messages using Acme Mail and `mail`.

Both `upas/nfs` and `upas/smtp` used `tlsClient()` in the original plan9 code. In the nfs function `imapdial()`, the call to tlsClient was replaced with `stunnel3` on ported systems. This PR simply replaces the tlsClient call in smtp with stunnel as well.

Because tlsClient was called differently in the two (nfs called the userland function, while smtp used the library function), I had to patch a copy of imapdial called `smtpdial()` into the smtp code. smtpdial then replaces the dial call in the mxdial function.

I am very open to suggestions on how to make this solution more elegant!