### PR TITLE
Correctly quote IMAP LOGIN command arguments

### DIFF
--- a/src/cmd/upas/nfs/imap.c
+++ b/src/cmd/upas/nfs/imap.c
@@ -214,7 +214,7 @@ imaplogin(Imap *z)
 		return -1;
 	}
 
-	sx = imapcmdsx(z, nil, "LOGIN %Z %Z", up->user, up->passwd);
+	sx = imapcmdsx(z, nil, "LOGIN %#Z %#Z", up->user, up->passwd);
 	freeup(up);
 	if(sx == nil)
 		return -1;


### PR DESCRIPTION
According to RFC 3501 the arguments to the LOGIN command should be quoted strings (or length prefixed string literals). Without quoting, authentication to some IMAP servers (e.g. Dovecot) will fail.