### PR TITLE
fontsrv: omit box-drawing characters from line struts on macOS

### DIFF
--- a/src/cmd/fontsrv/osx.c
+++ b/src/cmd/fontsrv/osx.c
@@ -104,7 +104,7 @@ static char *lines[] = {
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 	"abcdefghijklmnopqrstuvwxyz",
 	"g",
-	"┌┬┐├┼┤└┴┘│─",
+	"ÁĂÇÂÄĊÀČĀĄÅÃĥľƒ",
 	"ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει.",
 	"私はガラスを食べられます。それは私を傷つけません。",
 	"Aš galiu valgyti stiklą ir jis manęs nežeidžia",


### PR DESCRIPTION
For some fonts, using box-drawing characters in the representative
text for computing the line height results in it being uncomfortably
high. Replace them with accented capitals and tall lower-case letters
which lead to a more conservative increase in the line height.

Fixes #162.