### PR TITLE
fontsrv: x11 uses FC_POSTSCRIPT_NAME

### DIFF
--- a/src/cmd/fontsrv/x11.c
+++ b/src/cmd/fontsrv/x11.c
@@ -40,7 +40,7 @@ loadfonts(void)
 		int index;
 		FcPattern *pat = sysfonts->fonts[i];
 
-		if(FcPatternGetString(pat, FC_FULLNAME, 0, &fullname) != FcResultMatch ||
+		if(FcPatternGetString(pat, FC_POSTSCRIPT_NAME, 0, &fullname) != FcResultMatch ||
 		   FcPatternGetString(pat, FC_FILE, 0, &fontfile) != FcResultMatch     ||
 		   FcPatternGetInteger(pat, FC_INDEX, 0, &index) != FcResultMatch)
 			continue;


### PR DESCRIPTION
This makes fontsrv use the PostScript font names on X11.
The PostScript font names contains only alphanumeric and
hyphens.  This allows us to use the Font command in acme.
It also matches the font names used by fontsrv on macOS,
which has been using PostScript font names.

Note: this patch changes font names for X11 users.
Those who uses X11 need to remove the spaces from the font names in their profile or acme.dump.