### PR TITLE
Makefile now runs ./INSTALL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-%:
+all:
 	@sh -c "./INSTALL"
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 %:
-	@echo read the README file
+	@sh -c "./INSTALL"
 


### PR DESCRIPTION
I just made a slight change to the Makefile, so it now will run ./INSTALL instead of telling the user to RTFM. Might be useful for automated installers.