### PR TITLE
Fixing tar options for mkfile in unix directory

### DIFF
--- a/unix/mkfile
+++ b/unix/mkfile
@@ -38,15 +38,15 @@ test-%:V:
 
 lib%.tgz:V:
 	mk new-$stem
-	tar cf - lib$stem | gzip > $target
+	tar c lib$stem | gzip > $target
 
 libregexp9.tgz:V:
 	mk new-regexp
-	tar cf - libregexp | gzip >$target
+	tar c libregexp | gzip >$target
 
 mk.tgz:V:
 	mk new-mk
-	tar cf - mk | gzip > $target
+	tar c mk | gzip > $target
 
 mk-with-libs.tgz:V:
 	mk new-utf 
@@ -59,7 +59,7 @@ mk-with-libs.tgz:V:
 	mv libutf libfmt libbio libregexp mk zot
 	mv zot mk
 	cp make/Makefile.all mk/Makefile
-	tar cf - mk | gzip > $target
+	tar c mk | gzip > $target
 	rm -r mk
 
 tgz:V: libutf.tgz libfmt.tgz libregexp9.tgz libbio.tgz mk.tgz mk-with-libs.tgz


### PR DESCRIPTION
Was playing around and attempted mk tgz in plan9front/unix and it failed (create a '-' tar archive). Per tar man file, this version of tar should use tar c <name> to generate an archive from standard out.

This is just a simple patch to make that change. 