### PR TITLE
Add '@' to list of characters expected to be part of file/directory name.

### DIFF
--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -378,7 +378,7 @@ search(Text *ct, Rune *r, uint n)
 int
 isfilec(Rune r)
 {
-	static Rune Lx[] = { '.', '-', '+', '/', ':', 0 };
+	static Rune Lx[] = { '.', '-', '+', '/', ':', '@', 0 };
 	if(isalnum(r))
 		return TRUE;
 	if(runestrchr(Lx, r))


### PR DESCRIPTION
Mainly because Go's pkg/mod directory is full of directories
named pkg@version.