### PR TITLE
fix segfault in grep -e if no argument was provided

### DIFF
--- a/src/cmd/grep/main.c
+++ b/src/cmd/grep/main.c
@@ -13,6 +13,7 @@ void
 main(int argc, char *argv[])
 {
 	int i, status;
+	char* arge;
 
 	ARGBEGIN {
 	default:
@@ -29,9 +30,12 @@ main(int argc, char *argv[])
 		break;
 
 	case 'e':
+		arge = ARGF();
+		if(arge == nil)
+			usage();
 		flags['e']++;
 		lineno = 0;
-		str2top(ARGF());
+		str2top(arge);
 		break;
 
 	case 'f':

--- a/src/cmd/grep/main.c
+++ b/src/cmd/grep/main.c
@@ -13,7 +13,6 @@ void
 main(int argc, char *argv[])
 {
 	int i, status;
-	char* arge;
 
 	ARGBEGIN {
 	default:
@@ -30,12 +29,9 @@ main(int argc, char *argv[])
 		break;
 
 	case 'e':
-		arge = ARGF();
-		if(arge == nil)
-			usage();
 		flags['e']++;
 		lineno = 0;
-		str2top(arge);
+		str2top(EARGF(usage()));
 		break;
 
 	case 'f':


### PR DESCRIPTION
Previously if you performed `grep -e` with no arguments you'd get a segfault.

After adding a comparison for nil there is no segfault with a `grep -e`  and you get usage as would be expected.

I don't like adding a variable for this, but I didn't see a better way immediately. Thoughts?