### PR TITLE
acme: avoid division by zero when resizing col

### DIFF
--- a/src/cmd/acme/cols.c
+++ b/src/cmd/acme/cols.c
@@ -250,8 +250,12 @@ colresize(Column *c, Rectangle r)
 		w->maxlines = 0;
 		if(i == c->nw-1)
 			r1.max.y = r.max.y;
-		else
-			r1.max.y = r1.min.y+(Dy(w->r)+Border)*Dy(r)/Dy(c->r);
+		else{
+			r1.max.y = r1.min.y;
+			if(Dy(c->r) != 0){
+				r1.max.y += (Dy(w->r)+Border)*Dy(r)/Dy(c->r);
+			}
+		}
 		r1.max.y = max(r1.max.y, r1.min.y + Border+font->height);
 		r2 = r1;
 		r2.max.y = r2.min.y+Border;


### PR DESCRIPTION
To reproduce, create a column with at least two windows and resize
acme to have almost zero height.