### PR TITLE
fontsrv: disable font smoothing on osx

### DIFF
--- a/src/cmd/fontsrv/mkfile
+++ b/src/cmd/fontsrv/mkfile
@@ -1,4 +1,5 @@
 <$PLAN9/src/mkhdr
+<|osxvers
 <|sh ../devdraw/mkwsysrules.sh
 <|sh freetyperules.sh $WSYSTYPE $X11H
 

--- a/src/cmd/fontsrv/osx.c
+++ b/src/cmd/fontsrv/osx.c
@@ -277,6 +277,9 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 
 	CGContextSetAllowsAntialiasing(ctxt, antialias);
 	CGContextSetTextPosition(ctxt, 0, 0);	// XXX
+#if OSX_VERSION >= 101400
+	CGContextSetAllowsFontSmoothing(ctxt, false);
+#endif
 
 	x = 0;
 	for(i=lo; i<=hi; i++, fc++) {


### PR DESCRIPTION
macOS Mojave version 10.14 starts to disable font smoothing.
We disable font smoothing for OSX_VERSION >= 101400 to match the
system default font rendering.
It also makes the font rendering on macOS similar to that on X11.
<img width="505" alt="fontsrv" src="https://user-images.githubusercontent.com/89739/47478616-957db800-d7ef-11e8-9c9c-877e90557cf4.png">
