### PR TITLE
9term: fix getpts on FreeBSD 11.2

### DIFF
--- a/src/cmd/9term/FreeBSD.c
+++ b/src/cmd/9term/FreeBSD.c
@@ -1,1 +1,17 @@
+#define getpts not_using_this_getpts
 #include "bsdpty.c"
+#undef getpts
+
+#include <libutil.h>
+
+int
+getpts(int fd[], char *slave)
+{
+	if(openpty(&fd[1], &fd[0], NULL, NULL, NULL) >= 0){
+		fchmod(fd[1], 0620);
+		strcpy(slave, ttyname(fd[0]));
+		return 0;
+	}
+	sysfatal("no ptys");
+	return 0;
+}


### PR DESCRIPTION
Opening /dev/ptyXX files fails on recent
FreeBSD versions.

Following the same fix being applied to
Linux, OpenBSD, and Darwin, we use openpty
to open a pseudoterminal in openpts.