### PR TITLE
devdraw: macOS metal screen no longer translates ctrl-h

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -841,7 +841,6 @@ keycvt(uint code)
 {
 	switch(code){
 	case '\r': return '\n';
-	case '\b': return 127;
 	case 127: return '\b';
 	case NSUpArrowFunctionKey: return Kup;
 	case NSDownArrowFunctionKey: return Kdown;


### PR DESCRIPTION
Fix #204 