### PR TITLE
samterm: Strict check Kcmd non-typing character to handle Mac IME.

### DIFF
--- a/src/cmd/samterm/main.c
+++ b/src/cmd/samterm/main.c
@@ -512,10 +512,11 @@ nontypingkey(int c)
 	case PAGEUP:
 	case RIGHTARROW:
 	case SCROLLKEY:
+	case CUT:
+	case COPY:
+	case PASTE:    
 		return 1;
 	}
-	if(c >= Kcmd)
-		return 1;
 	return 0;
 }
 


### PR DESCRIPTION
Samterm should strict check non-typing character Kcmd to handling Mac IME marked range.

Without this patch illegal range deleted:
![sam-ime](https://user-images.githubusercontent.com/236528/48658558-776e4500-ea87-11e8-907d-a51189f2e6f2.gif)

With this patch:
![sam-ime-fix](https://user-images.githubusercontent.com/236528/48658559-8b19ab80-ea87-11e8-87c9-5388889fbe42.gif)

This change was included in my closed patch of support Mac IME #121 
But not included changes of #194, so I sent this again 😀 

And this patch also solves can't input Zenkaku alphabet character(e.g `ｈ`)  in sam.