### PR TITLE
devdraw: Handle windowDidResize to support non-live window resize.

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -384,6 +384,13 @@ struct Cursors {
 	return YES;
 }
 
+- (void)windowDidResize:(NSNotification *)notification
+{
+	if(![myContent inLiveResize] && img) {
+		resizeimg();
+	}
+}
+
 - (void)windowDidBecomeKey:(id)arg
 {
         [myContent sendmouse:0];
@@ -1148,7 +1155,6 @@ resizewindow(Rectangle r)
 
 		s = [myContent convertSizeFromBacking:NSMakeSize(Dx(r), Dy(r))];
 		[win setContentSize:s];
-		resizeimg();
 	});
 }
 


### PR DESCRIPTION
Some window management tools (e.g [Moom](https://manytricks.com/moom/) which I'm using on my mac) using Accessibility API to support resizing window from keyboard.
And current Metal cocoa screen (Implemented in #194) only redraw after live resize event to improve performance.
But window resizing through accessibility API does not sent live-resize event.
So I'm add a handler for windowDidResize event, and check inLiveResize flag to skip inefficient redraw.

