### PR TITLE
acme: macOS (emacs?) keyboard shortcuts

### DIFF
--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -488,7 +488,7 @@ keyboardthread(void *v)
 			t = typetext;
 			if(t!=nil && t->col!=nil && !(r==Kdown || r==Kleft || r==Kright))	/* scrolling doesn't change activecol */
 				activecol = t->col;
-			if(t!=nil && t->w!=nil)
+			if(t!=nil && t->w!=nil && t->w->body.file)
 				t->w->body.file->curtext = &t->w->body;
 			if(timer != nil)
 				timercancel(timer);

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -19,6 +19,7 @@ Font*	getfont(int, int, char*);
 char*	getarg(Text*, int, int, Rune**, int*);
 char*	getbytearg(Text*, int, int, char**);
 void	new(Text*, Text*, Text*, int, int, Rune*, int);
+void	newcol(Text*, Text*, Text*, int, int, Rune*, int);
 void	undo(Text*, Text*, Text*, int, int, Rune*, int);
 void	scrsleep(uint);
 void	savemouse(Window*);
@@ -57,6 +58,8 @@ void	get(Text*, Text*, Text*, int, int, Rune*, int);
 void	put(Text*, Text*, Text*, int, int, Rune*, int);
 void	putfile(File*, int, int, Rune*, int);
 void	fontx(Text*, Text*, Text*, int, int, Rune*, int);
+void	del(Text*, Text*, Text*, int, int, Rune*, int);
+void	delcol(Text*, Text*, Text*, int, int, Rune*, int);
 #undef isalnum
 #define isalnum acmeisalnum
 int	isalnum(Rune);

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -593,7 +593,7 @@ textcomplete(Text *t)
 	char *s, *dirs;
 	Runestr dir;
 
-	/* control-f: filename completion; works back to white space or / */
+	/* filename completion; works back to white space or / */
 	if(t->q0<t->file->b.nc && textreadc(t, t->q0)>' ')	/* must be at end of word */
 		return nil;
 	nstr = textfilewidth(t, t->q0, TRUE);
@@ -681,16 +681,19 @@ texttype(Text *t, Rune r)
 	nr = 1;
 	rp = &r;
 	switch(r){
+	case 0x02:	/* ^B: move left */
 	case Kleft:
 		typecommit(t);
 		if(t->q0 > 0)
 			textshow(t, t->q0-1, t->q0-1, TRUE);
 		return;
+	case 0x06:	/* ^F: move right */
 	case Kright:
 		typecommit(t);
 		if(t->q1 < t->file->b.nc)
 			textshow(t, t->q1+1, t->q1+1, TRUE);
 		return;
+	case 0x0e:	/* ^N: move down */
 	case Kdown:
 		if(t->what == Tag)
 			goto Tagdown;
@@ -709,6 +712,7 @@ texttype(Text *t, Rune r)
 		q0 = t->org+frcharofpt(&t->fr, Pt(t->fr.r.min.x, t->fr.r.min.y+n*t->fr.font->height));
 		textsetorigin(t, q0, TRUE);
 		return;
+	case 0x10:	/* ^P: move up */
 	case Kup:
 		if(t->what == Tag)
 			goto Tagup;
@@ -853,7 +857,7 @@ texttype(Text *t, Rune r)
 	}
 	textshow(t, t->q0, t->q0, 1);
 	switch(r){
-	case 0x06:	/* ^F: complete */
+	case Kcmd+'/':	/* %/: complete */
 	case Kins:
 		typecommit(t);
 		rp = textcomplete(t);

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -764,6 +764,26 @@ texttype(Text *t, Rune r)
 		typecommit(t);
 		cut(t, t, nil, TRUE, FALSE, nil, 0);
 		return;
+	case Kcmd+'n':	/* %N: new */
+		typecommit(t);
+		new(t, nil, nil, XXX, XXX, nil, 0);
+		return;
+	case Kcmd+'N':	/* %-shift-N: newcol */
+		typecommit(t);
+		newcol(t, nil, nil, XXX, XXX, nil, 0);
+		return;
+	case Kcmd+'s':	/* %S: put */
+		typecommit(t);
+		put(t, nil, nil, XXX, XXX, nil, 0);
+		return;
+	case Kcmd+'w':	/* %W: del */
+		typecommit(t);
+		del(t, nil, nil, FALSE, XXX, nil, 0);
+		return;
+	case Kcmd+'W':	/* %-shift-W: delcol */
+		typecommit(t);
+		delcol(t, nil, nil, XXX, XXX, nil, 0);
+		return;
 	case Kcmd+'z':	/* %Z: undo */
 	 	typecommit(t);
 		undo(t, nil, nil, TRUE, 0, nil, 0);

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -760,6 +760,14 @@ texttype(Text *t, Rune r)
 			q0++;
 		textshow(t, q0, q0, TRUE);
 		return;
+	case 0x0c:	/* ^L: clear selection */
+		typecommit(t);
+		textshow(t, t->q0, t->q0, TRUE);
+		return;
+	case Kcmd+'a': /* %A: select all */
+		typecommit(t);
+		textshow(t, 0, t->file->b.nc, TRUE);
+		return;
 	case Kcmd+'c':	/* %C: copy */
 		typecommit(t);
 		cut(t, t, nil, TRUE, FALSE, nil, 0);

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -564,7 +564,7 @@ winsettag(Window *w)
 	f = w->body.file;
 	for(i=0; i<f->ntext; i++){
 		v = f->text[i]->w;
-		if(v->col->safe || v->body.fr.maxlines>0)
+		if(v->col && v->col->safe || v->body.fr.maxlines>0)
 			winsettag1(v);
 	}
 }


### PR DESCRIPTION
This is a work in progress  to implement more keyboard shortcuts to ACME, emulating the behavior of macOS (should I say emacs?) when editing on the terminal. For example:

Command+A will select all text, Control+A will put the cursor on the beginning of line, Control+D will delete one character forward, etc. This will work on Windows too with the Windows Key and I think it will do the same on Linux.

Let me know if there is any interest in doing this kind of modification in ACME. I know the implementation is bugged and I don't have much experience with ACME code, so I need some help here.