### PR TITLE
libdraw,devdraw: fix compatibility with old 16x16 cursor protocol

### DIFF
--- a/src/cmd/devdraw/cocoa-srv.c
+++ b/src/cmd/devdraw/cocoa-srv.c
@@ -165,6 +165,14 @@ runmsg(Wsysmsg *m)
 		if(m->arrowcursor)
 			setcursor(nil, nil);
 		else
+			setcursor(&m->cursor, nil);
+		replymsg(m);
+		break;
+
+	case Tcursor2:
+		if(m->arrowcursor)
+			setcursor(nil, nil);
+		else
 			setcursor(&m->cursor, &m->cursor2);
 		replymsg(m);
 		break;

--- a/src/cmd/devdraw/x11-srv.c
+++ b/src/cmd/devdraw/x11-srv.c
@@ -332,6 +332,7 @@ runmsg(Wsysmsg *m)
 		break;
 
 	case Tcursor:
+	case Tcursor2:
 		if(m->arrowcursor)
 			_xsetcursor(nil);
 		else

--- a/src/libdraw/drawclient.c
+++ b/src/libdraw/drawclient.c
@@ -296,7 +296,7 @@ _displaycursor(Display *d, Cursor *c, Cursor2 *c2)
 {
 	Wsysmsg tx, rx;
 	
-	tx.type = Tcursor;
+	tx.type = Tcursor2;
 	if(c == nil){
 		memset(&tx.cursor, 0, sizeof tx.cursor);
 		memset(&tx.cursor2, 0, sizeof tx.cursor2);

--- a/src/libdraw/drawfcall.c
+++ b/src/libdraw/drawfcall.c
@@ -48,6 +48,7 @@ sizeW2M(Wsysmsg *m)
 	case Rbouncemouse:
 	case Rmoveto:
 	case Rcursor:
+	case Rcursor2:
 	case Trdkbd:
 	case Rlabel:
 	case Rinit:
@@ -64,6 +65,8 @@ sizeW2M(Wsysmsg *m)
 	case Tmoveto:
 		return 4+1+1+4+4;
 	case Tcursor:
+		return 4+1+1+4+4+2*16+2*16+1;
+	case Tcursor2:
 		return 4+1+1+4+4+2*16+2*16+4+4+4*32+4*32+1;
 	case Rerror:
 		return 4+1+1+_stringsize(m->error);
@@ -108,6 +111,7 @@ convW2M(Wsysmsg *m, uchar *p, uint n)
 	case Rbouncemouse:
 	case Rmoveto:
 	case Rcursor:
+	case Rcursor2:
 	case Trdkbd:
 	case Rlabel:
 	case Rinit:
@@ -137,6 +141,13 @@ convW2M(Wsysmsg *m, uchar *p, uint n)
 		PUT(p+10, m->mouse.xy.y);
 		break;
 	case Tcursor:
+		PUT(p+6, m->cursor.offset.x);
+		PUT(p+10, m->cursor.offset.y);
+		memmove(p+14, m->cursor.clr, sizeof m->cursor.clr);
+		memmove(p+46, m->cursor.set, sizeof m->cursor.set);
+		p[78] = m->arrowcursor;
+		break;
+	case Tcursor2:
 		PUT(p+6, m->cursor.offset.x);
 		PUT(p+10, m->cursor.offset.y);
 		memmove(p+14, m->cursor.clr, sizeof m->cursor.clr);
@@ -200,6 +211,7 @@ convM2W(uchar *p, uint n, Wsysmsg *m)
 	case Rbouncemouse:
 	case Rmoveto:
 	case Rcursor:
+	case Rcursor2:
 	case Trdkbd:
 	case Rlabel:
 	case Rinit:
@@ -229,6 +241,13 @@ convM2W(uchar *p, uint n, Wsysmsg *m)
 		GET(p+10, m->mouse.xy.y);
 		break;
 	case Tcursor:
+		GET(p+6, m->cursor.offset.x);
+		GET(p+10, m->cursor.offset.y);
+		memmove(m->cursor.clr, p+14, sizeof m->cursor.clr);
+		memmove(m->cursor.set, p+46, sizeof m->cursor.set);
+		m->arrowcursor = p[78];
+		break;
+	case Tcursor2:
 		GET(p+6, m->cursor.offset.x);
 		GET(p+10, m->cursor.offset.y);
 		memmove(m->cursor.clr, p+14, sizeof m->cursor.clr);
@@ -319,8 +338,12 @@ drawfcallfmt(Fmt *fmt)
 		return fmtprint(fmt, "Rmoveto");
 	case Tcursor:
 		return fmtprint(fmt, "Tcursor arrow=%d", m->arrowcursor);
+	case Tcursor2:
+		return fmtprint(fmt, "Tcursor2 arrow=%d", m->arrowcursor);
 	case Rcursor:
 		return fmtprint(fmt, "Rcursor");
+	case Rcursor2:
+		return fmtprint(fmt, "Rcursor2");
 	case Trdkbd:
 		return fmtprint(fmt, "Trdkbd");
 	case Rrdkbd:


### PR DESCRIPTION
Some libraries that depend on devdraw don't know about
32x32 cursor -- mainly 9fans.net/go/draw.