### PR TITLE
acme: fix X, Y command crashing with extra locks

### DIFF
--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -508,7 +508,6 @@ enum	/* editing */
 	Collecting
 };
 
-uint		globalincref;
 uint		seq;
 uint		maxtab;	/* size of a tab, in units of the '0' character */
 

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -29,8 +29,6 @@ wininit(Window *w, Window *clone, Rectangle r)
 	w->body.w = w;
 	w->id = ++winid;
 	incref(&w->ref);
-	if(globalincref)
-		incref(&w->ref);
 	w->ctlfid = ~0;
 	w->utflastqid = -1;
 	r1 = r;


### PR DESCRIPTION
When mouse issues a command, the window that has the mouse is locked
with winlock, then the command is run, and then winunlock.  Runpipe
is coping this mechanism by sequentially calling incref, run (which
contains a winclose that does a decref, winunlock, and finally
winlock again.  This is fine for the usual pipe_cmd, but for X_cmd,
all except one window does not have the lock to begin with.  Acme
would crash when such X, Y command were run and winunlock were
called on a window without a prior winlock.

This patch fix the issue by adding extra winunlock/winlock in X_cmd
to deal with existing locks, and applying winlock/winunlock for each
matching window in filelooper.

Fixes #9 #219 