### PR TITLE
quote1: try to fetch text from tmux if acme and 9term are not present

### DIFF
--- a/bin/quote1
+++ b/bin/quote1
@@ -7,6 +7,8 @@ fn text {
 		9p read acme/$winid/body
 	if not if(~ $text9term unix!*)
 		dial -e $text9term </dev/null
+	if not if(~ $TMUX ?*)
+		tmux capture-pane -p
 	if not
 		status=''
 }


### PR DESCRIPTION
This patch allows using the `"` and `""` commands from withing tmux. This proved
useful to me using plan9ports, in particular `rc`, over ssh, i.e. where I can't use acme.

I'm not sure if it is against plan9ports philosophy to add special cases for tools like tmux.
I still use tmux a lot, so this patch is useful to me and I wanted to share it.

Feel free to decline the pull request.