### PR TITLE
fix return value of nbrecvul

### DIFF
--- a/src/libthread/channel.c
+++ b/src/libthread/channel.c
@@ -413,6 +413,6 @@ channbrecvul(Channel *c)
 
 	if(_chanop(c, CHANRCV, &val, 0) > 0)
 		return val;
-	return -1;
+	return 0;
 }
 


### PR DESCRIPTION
All,

Within thread(2) there is a bad return value for nbrecvul(2), which returns a negative value from a function with an unsigned return type, implying an overflow. 

Currently plan9port does:

```
ulong
channbrecvul(Channel *c) 
{
    ulong val;

    if(_chanop(c, CHANRCV, &val, 0) > 0)
        return val;
    return -1; 
}
```

9legacy does:

```
ulong
nbrecvul(Channel *c)
{
	ulong v;

	channelsize(c, sizeof(ulong));
	if(nbrecv(c, &v) == 0)
		return 0;
	return v;
}
```

I'm not sure if this is the best fix, but it at least means there isn't an overflow. Ostensibly I'd think that making the base look more like Plan 9 source would be preferred, but I feel like that's a more major change, if even possible in this case.

Credit to tkk for pointing this bug out.
