### PR TITLE
prefer integrated GPU for macOS metal rendering

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -153,6 +153,7 @@ threadmain(int argc, char **argv)
 	id<MTLLibrary> library;
 	MTLRenderPipelineDescriptor *pipelineDesc;
 	NSError *error;
+	NSArray *allDevices;
 
 	const NSWindowStyleMask Winstyle = NSWindowStyleMaskTitled
 		| NSWindowStyleMaskClosable
@@ -197,8 +198,18 @@ threadmain(int argc, char **argv)
 	[win setContentView:myContent];
 	[myContent setWantsLayer:YES];
 	[myContent setLayerContentsRedrawPolicy:NSViewLayerContentsRedrawOnSetNeedsDisplay];
-
-	device = MTLCreateSystemDefaultDevice();
+	
+	device = nil;
+	allDevices = MTLCopyAllDevices();
+	for(id mtlDevice in allDevices) {
+		if ([mtlDevice isLowPower] && ![mtlDevice isRemovable]) {
+			device = mtlDevice;
+			break;
+		}
+	}
+	if(!device)
+		device = MTLCreateSystemDefaultDevice();
+	
 	commandQueue = [device newCommandQueue];
 
 	layer = (DrawLayer *)[myContent layer];


### PR DESCRIPTION
hi, apologies in advance for how rough this might be: I noticed that acme was marked "Yes" in the "Requires High Perf GPU" column in macOS' Activity Monitor app on my dual-GPU macbook. Selecting a low-power integrated GPU seems to change this behavior, I'm unaware if there's a reason to use the default/high-performance GPU for devdraw.