### PR TITLE
devdraw: respond to windowDidBecomeKey on darwin

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -373,6 +373,11 @@ struct Cursors {
 	return YES;
 }
 
+- (void)windowDidBecomeKey:(id)arg
+{
+        [myContent sendmouse:0];
+}
+
 @end
 
 @implementation DevDrawView


### PR DESCRIPTION
Fixes bug where devdraw does not "notice" mouse position after task
switch. Fixes https://github.com/9fans/plan9port/issues/232.

In Acme, which uses "focus follows mouse", this bug is particularly annoying. The effect is that I often have to wiggle my mouse (or touch the trackpad) after switching back to Acme with Cmd-Tab.