### PR TITLE
devdraw: cocoa metal returns early in _flushmemscreen for wrong rectangles

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -982,6 +982,10 @@ void
 _flushmemscreen(Rectangle r)
 {
 	LOG(@"_flushmemscreen(%d,%d,%d,%d)", r.min.x, r.min.y, Dx(r), Dy(r));
+	if(!rectinrect(r, Rect(0, 0, texture.width, texture.height))){
+		LOG(@"Rectangle is out of bounds, return.");
+		return;
+	}
 
 	@autoreleasepool{
 		[texture


### PR DESCRIPTION
It is possible to receive multiple screen resize events, and resizeimg
would be called for different sizes, before _flushmemscreen actually
gets called with rectangle sizes different from the most recent
resizeimg call.  The size mismatch would trigger illegal memory
access inside _flushmemscreen.

This commit protects _flushmemscreen by returning early if the requested
rectangle is outside of the current texture rectangle.

fixes #221