### PR TITLE
Various Tweaks and Improvements to Sam

### DIFF
--- a/src/cmd/sam/sam.c
+++ b/src/cmd/sam/sam.c
@@ -43,7 +43,9 @@ main(int _argc, char **_argv)
 	volatile int i, argc;
 	char **volatile argv;
 	String *t;
-	char *termargs[10], **ap;
+	char *termargs[32], **ap;
+	char *p;
+	int ilen;
 	
 	argc = _argc;
 	argv = _argv;
@@ -75,6 +77,14 @@ main(int _argc, char **_argv)
 	case 'W':
 		*ap++ = "-W";
 		*ap++ = EARGF(usage());
+		break;
+	case 'i':
+		p = EARGF(usage());
+		ilen = atoi(p);
+		if ((ilen <= 0) || (ilen > 99))
+			usage();
+		*ap++ = "-i";
+		*ap++ = p;
 		break;
 	}ARGEND
 	*ap = nil;
@@ -119,7 +129,7 @@ main(int _argc, char **_argv)
 void
 usage(void)
 {
-	dprint("usage: sam [-d] [-t samterm] [-s sam name] [-r machine] [file ...]\n");
+	dprint("usage: sam [-d] [-t samterm] [-s sam name] [-r machine] [-i nspaces] [file ...]\n");
 	exits("usage");
 }
 

--- a/src/cmd/samterm/plan9.c
+++ b/src/cmd/samterm/plan9.c
@@ -25,10 +25,20 @@ static char *exname;
 
 #define STACK 16384
 
+// void
+// indentcfg(int argc, char **argv)
+// {
+// 	for (int i = 0; i < argc - 1; ++i) {
+// 		char *arg = argv[i];
+// 		if (!strcmp("-i", arg))
+// 			indentsz = atoi(argv[i + 1]);
+// 	}
+// }
+
 void
 usage(void)
 {
-	fprint(2, "usage: samterm -a -W winsize\n");
+	fprint(2, "usage: samterm -a -W winsize [-i indent]\n");
 	threadexitsall("usage");
 }
 
@@ -36,6 +46,7 @@ void
 getscreen(int argc, char **argv)
 {
 	char *t;
+	char *iarg;
 
 	ARGBEGIN{
 	case 'a':
@@ -43,6 +54,12 @@ getscreen(int argc, char **argv)
 		break;
 	case 'W':
 		winsize = EARGF(usage());
+		break;
+	case 'i':
+		iarg = EARGF(usage());
+		indentsz = atoi(iarg);
+		if (indentsz <= 0)
+			usage();
 		break;
 	default:
 		usage();

--- a/src/cmd/samterm/samterm.h
+++ b/src/cmd/samterm/samterm.h
@@ -89,6 +89,7 @@ extern int	plumbfd;
 extern int	hostfd[2];
 extern int	exiting;
 extern int	autoindent;
+extern int indentsz;
 
 #define gettext sam_gettext	/* stupid gcc built-in functions */
 Rune	*gettext(Flayer*, long, ulong*);


### PR DESCRIPTION
I've copied over my modifications of Sam/Samterm from [my fork of plan9port on GitLab](https://gitlab.com/ryukoposting/plan9port). The changes I've made are:

 - Added a new argument to samterm (and to Sam, but Sam merely passes the argument up into Samterm), `-i[nspaces]`. Giving `-i` with a number will cause tab keystrokes to insert the specified number of spaces instead. For example, `-i4` will make pressing the 'tab' key result in the insertion of 4 spaces, instead of a tab character. This makes life easier when working on projects where tabs are not the standard indenting character.
- The behavior of the delete key has been altered in samterm. Instead of behaving like the backspace key (deleting the character before dot), the delete key now will delete the character immediately following dot.
- The home key now moves dot to the beginning of the current line, instead of the beginning of the current file. The home key is also now indentation sensitive- if there are non-indenting (that is, not `'\t'` or `' '`) characters before dot, the home key will move dot to be directly before the first non-indenting character of the line. If all characters on the current line before dot are either `'\t'` or `' '`, then the home key will move dot to the beginning of the line.
- The end key moves dot to the end of the current line, instead of the end of the current file.

Obviously, my modifications may introduce behaviors that don't match the original Sam. I'm not sure how much you guys are interested in keeping the plan9port programs 100% faithful to the originals, but I think these changes make Sam much more practical for everyday use, without fundamentally altering its design.