### PR TITLE
auxstats: replace /proc ACPI calls with /sys ones

### DIFF
--- a/src/cmd/auxstats/Linux.c
+++ b/src/cmd/auxstats/Linux.c
@@ -26,36 +26,22 @@ void (*statfn[])(int) =
 void
 xapm(int first)
 {
-	static int fd = -1, fdb = -1;
-	int i, last = -1, curr = -1;
+	static int fd = -1;
+	int curr = -1;
 
 	if(first){
-		fd = open("/proc/acpi/battery/BAT0/info", OREAD);
-		fdb = open("/proc/acpi/battery/BAT0/state", OREAD);
+		fd = open("/sys/class/power_supply/BAT0/capacity", OREAD);
 		return;
 	}
-	if(fd == -1 || fdb == -1)
+	if(fd == -1)
 		return;
 
 	readfile(fd);
-	for(i=0; i<nline; i++){
-		tokens(i);
-		if(ntok < 3)
-			continue;
-		if(strcmp(tok[0], "last") == 0 && strcmp(tok[1], "full") == 0)
-			last = atoi(tok[3]);
-	}
-	readfile(fdb);
-	for(i = 0; i < nline; i++) {
-		tokens(i);
-		if(ntok < 3)
-			continue;
-		if(strcmp(tok[0], "remaining") == 0 && strcmp(tok[1], "capacity:") == 0)
-			curr = atoi(tok[2]);
-	}
+	tokens(0);
+	curr = atoi(tok[0]);
 			
-	if(curr != -1 && last != -1)
-		Bprint(&bout, "battery =%d 100\n", (int)(((float)curr/(float)last)*100.0));
+	if(curr != -1)
+		Bprint(&bout, "battery =%d 100\n", curr);
 
 }
 	


### PR DESCRIPTION
According to <https://askubuntu.com/a/309146>, use of `/proc/acpi` to
get battery usage is deprecated. This commit replaces the two files from
this API with the single file `/sys/class/power_supply/BAT0/capacity`,
simultaneously removing the need to calculate battery percentage.