### PR TITLE
9l: support FreeBSD ≥ 12 (fixes issue #247)

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -19,7 +19,7 @@ case "$tag" in
 	5.2.*)
 		extralibs="$extralibs -lkse"
 		;;
-	[5-9].*|1[0-1].*)
+	[5-9].*|1[0-9].*)
 		extralibs="$extralibs -lpthread"
 		;;
 	esac


### PR DESCRIPTION
Per the discussion on issue #247: makes 9l correct for FreeBSD 12, and we won't have to revisit it until FreeBSD 20, modulo other changes.