### PR TITLE
plumber: fix EOF detection on writes to rules file

### DIFF
--- a/src/cmd/plumb/rules.c
+++ b/src/cmd/plumb/rules.c
@@ -736,8 +736,8 @@ morerules(uchar *text, int done)
 		 */
 		endofrule = nil;
 		for(s=text; *s!='\0'; s++)
-			if(*s=='\n' && *++s=='\n')
-				endofrule = s+1;
+			if(*s=='\n' && *(s+1)=='\n')
+				endofrule = s+2;
 		if(endofrule == nil)
 			return text;
 		input->end = endofrule;
@@ -772,7 +772,7 @@ writerules(char *s, int n)
 		tmp = stringof(s, n);
 		text = (uchar*)concat((char*)text, tmp);
 		free(tmp);
-		text = morerules(text, s==nil);
+		text = morerules(text, n==0);
 	}
 	if(s == nil){
 		free(text);


### PR DESCRIPTION
Instead of checking Fcall.data==nil, check Fcall.count==0.
The former check always fails after `gcc -O2` optimizations
(gcc version 8.3.0).

Also fix an out-of-bound read detected by valgrind:
```
==31162== Invalid read of size 1
==31162==    at 0x11005E: morerules (rules.c:739)
==31162==    by 0x110254: writerules (rules.c:775)
==31162==    by 0x10D2FE: fsyswrite (fsys.c:848)
==31162==    by 0x10C304: fsysproc (fsys.c:248)
==31162==    by 0x112E8C: threadstart (thread.c:96)
==31162==    by 0x4A682BF: ??? (in /usr/lib/libc-2.29.so)
==31162==  Address 0x4ea984a is 0 bytes after a block of size 250 alloc'd
==31162==    at 0x483AD7B: realloc (vg_replace_malloc.c:826)
==31162==    by 0x1196F3: p9realloc (malloc.c:53)
==31162==    by 0x10BDFD: erealloc (plumber.c:124)
==31162==    by 0x10FCD9: concat (rules.c:642)
==31162==    by 0x10FCD9: concat (rules.c:635)
==31162==    by 0x110230: writerules (rules.c:773)
==31162==    by 0x10D2FE: fsyswrite (fsys.c:848)
==31162==    by 0x10C304: fsysproc (fsys.c:248)
==31162==    by 0x112E8C: threadstart (thread.c:96)
==31162==    by 0x4A682BF: ??? (in /usr/lib/libc-2.29.so)
```

Fixes #256