### PR TITLE
acme: send/receive incl attr in plumb message

### DIFF
--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -79,13 +79,15 @@ startplumbing(void)
 }
 
 void
-addinclattr(Window *w, Plumbattr *attr){
+addinclattr(Window *w, Plumbattr *attr)
+{
 	int i, size=0;
 	Rune *dirs=0;
 	char *s, *a;
 	Plumbattr *p;
 
-	if(w == nil || w->nincl <= 0) return;
+	if(w == nil || w->nincl <= 0)
+		return;
 	for(i=0; i<w->nincl; i++){
 		int n;
 		Rune *d, *r;
@@ -263,12 +265,13 @@ plumbgetc(void *a, uint n)
 }
 
 void
-plumbincl(Window *w, char *incl){
+plumbincl(Window *w, char *incl)
+{
 	Rune *dirs, *dir, *r;
 	int n;
 
-	if(incl == nil || w == nil) return;
-
+	if(incl == nil || w == nil)
+		return;
 	dirs = bytetorune(incl, &n);
 	if(dirs[0] == '\0') return;
 	for(r=dir=dirs; r<dirs+n; r++){


### PR DESCRIPTION
Acme will plumb files instead of opening when possible. This makes it so that new windows opened do not inherit Incl directories while the plumber is running. Fixed by adding an "incl" attribute to the plumb message that contains the list of directories, delimited by '|'.
