### PR TITLE
cmd/devdraw: set color space on CAMetalLayer

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -217,6 +217,7 @@ threadmain(int argc, char **argv)
 	layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 	layer.framebufferOnly = YES;
 	layer.opaque = YES;
+	layer.colorspace = CGColorSpaceCreateWithName((__bridge CFStringRef)NSDeviceWhiteColorSpace);
 
 	renderPass = [MTLRenderPassDescriptor renderPassDescriptor];
 	renderPass.colorAttachments[0].loadAction = MTLLoadActionDontCare;


### PR DESCRIPTION
Fixes https://github.com/9fans/plan9port/issues/260.

The macos "Night Shift" feature (automatic color temperature changes to try and match daylight / artificial light conditions) works as expected with windowed devdraw windows. But the moment I go to full screen (Cmd-F) and type something, the color space gets messed up.

This change, which I discovered through trial and error, seems to fix the problem.

