### PR TITLE
upas/nfs: fix null date when message is sent to plumber

### DIFF
--- a/src/cmd/upas/nfs/imap.c
+++ b/src/cmd/upas/nfs/imap.c
@@ -1468,6 +1468,7 @@ haveuid:
 			if(isatom(sx->sx[i], msgtab[j].name))
 				msgtab[j].fn(msg, sx->sx[i], sx->sx[i+1]);
 	}
+	msgplumb(msg, 0);
 }
 
 static void
@@ -1549,7 +1550,6 @@ xmsgenvelope(Msg *msg, Sx *k, Sx *v)
 	USED(k);
 	hdrfree(msg->part[0]->hdr);
 	msg->part[0]->hdr = parseenvelope(v);
-	msgplumb(msg, 0);
 }
 
 static struct {


### PR DESCRIPTION
    When fetching, messages are sent to plumber as soon as the ENVELOPE part is read.
    The date field of the message is sent when the INTERNALDATE part is read and
    there is no guarantee that this will be read before the ENVELOPE.
    This bug can be observed when using faces(1) which will retrieve messages with
    a null date and then always display a 'Jan 1' date instead of the correct one.
    The fix is to simply send the message to plumber after having read all parts,
    thus ensuring the message is complete.

Fix issue #262 