### PR TITLE
9l: Update and near-future-proof Linux version check

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -40,7 +40,9 @@ case "$tag" in
 	userpath=true
 	extralibs="$extralibs -lutil -lresolv"
 	case "${SYSVERSION:-`uname -r`}" in
-	2.6.* | 3.* | 4.*)
+	# Assuming that versions change more often than the name of
+	# the threading library, this should save some future updates.
+	2.6.* | [3-9].* | [1-9][0-9].*)
 		extralibs="$extralibs -lpthread"
 		;;
 	esac


### PR DESCRIPTION
The Linux kernel had another major version bump to 5, meaning that 9l wasn't picking up -lpthread. This patch should cover future versions, unless the entire version scheme or the name of the threading library changes.