### PR TITLE
Make venti's doc more accurate

### DIFF
--- a/man/man8/vbackup.8
+++ b/man/man8/vbackup.8
@@ -394,7 +394,7 @@ Mount the backups on a client machine using
 .IR vmount :
 .IP
 .EX
-# vmount udp!yourserver!nfs /dump
+# vmount yourserver /dump
 # ls /dump/bob/2005
 0510
 0511

--- a/man/man8/venti.8
+++ b/man/man8/venti.8
@@ -272,12 +272,30 @@ Set
 to
 .IR value .
 .TP
-.BI /graph/ name / param / param / \fR...
-A PNG image graphing the named run-time statistic over time.
-The details of names and parameters are undocumented;
-see
+.BI /graph?arg= name [&arg2= name] &graph= type &param= value \fR...
+A PNG image graphing the
+.IT name
+run-time statistic over time.
+The details of names and parameters are mostly undocumented;
+see the
+.BR graphname
+array in 
 .B httpd.c
-in the venti sources.
+in the venti code for a list of possible statistics. The
+.IR type
+of graph defaults to raw, see the
+.BR xgraph
+function for a list of types. Possible
+.IR param
+include the timeframe 
+.BR (t0
+and
+.BR t1)
+, the y limits 
+.BR (min
+and
+.BR max)
+ etc.
 .TP
 .B /log
 A list of all debugging logs present in the server's memory.
@@ -376,8 +394,7 @@ network address to announce venti service
 .TP
 .BI httpaddr " netaddr
 network address to announce HTTP service
-(default
-.BR tcp!*!http )
+(default is not to start the service)
 .TP
 .B queuewrites
 queue writes in memory

--- a/src/cmd/venti/srv/printarena.c
+++ b/src/cmd/venti/srv/printarena.c
@@ -5,7 +5,7 @@
 void
 usage(void)
 {
-	fprint(2, "usage: printarena arenafile [offset]\n");
+	fprint(2, "usage: printarena [-o aoffset] arenafile [offset]\n");
 	threadexitsall("usage");
 }
 


### PR DESCRIPTION
This is just some minor modifications to one usage string and two man pages, correcting some inaccuracies that bit me when I installed a venti server.