### PR TITLE
Bump max cache size from 4 MB to 128 MB to allow lots of children

### DIFF
--- a/src/cmd/vac/vac.c
+++ b/src/cmd/vac/vac.c
@@ -15,7 +15,7 @@ usage(void)
 enum
 {
 	BlockSize = 8*1024,
-	CacheSize = 4<<20,
+	CacheSize = 4<<25,
 };
 
 struct


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/plan9port-dev/pB0Cugp6Tt8

When a directory has lots of children, vac crashes because it runs out of cache.

Given that the cache is not allocated until it is actually used (save for 1% of
it as an index), this will not impact low memory machines.

Directories with tens of thousands of children do happen in real life.

This is IMHO a dirty fix, instead we should maybe look at making the cached
blocks global as soon as possible when we create a dir, instead of at the end,
but my knowledge of the codebase is not deep enough to make this change.