### PR TITLE
devdraw: cocoa metal screen adds a delayed update

### DIFF
--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -212,12 +212,19 @@ threadmain(int argc, char **argv)
 + (void)callsetNeedsDisplayInRect:(NSValue *)v
 {
 	NSRect r;
+	dispatch_time_t time;
 
 	r = [v rectValue];
 	LOG(@"callsetNeedsDisplayInRect(%g, %g, %g, %g)", r.origin.x, r.origin.y, r.size.width, r.size.height);
 	r = [win convertRectFromBacking:r];
 	LOG(@"setNeedsDisplayInRect(%g, %g, %g, %g)", r.origin.x, r.origin.y, r.size.width, r.size.height);
 	[layer setNeedsDisplayInRect:r];
+
+	time = dispatch_time(DISPATCH_TIME_NOW, 8 * NSEC_PER_MSEC);
+	dispatch_after(time, dispatch_get_main_queue(), ^(void){
+		[layer setNeedsDisplayInRect:r];
+	});
+
 	[myContent enlargeLastInputRect:r];
 }
 

--- a/src/cmd/devdraw/cocoa-screen-metal.m
+++ b/src/cmd/devdraw/cocoa-screen-metal.m
@@ -220,7 +220,7 @@ threadmain(int argc, char **argv)
 	LOG(@"setNeedsDisplayInRect(%g, %g, %g, %g)", r.origin.x, r.origin.y, r.size.width, r.size.height);
 	[layer setNeedsDisplayInRect:r];
 
-	time = dispatch_time(DISPATCH_TIME_NOW, 8 * NSEC_PER_MSEC);
+	time = dispatch_time(DISPATCH_TIME_NOW, 16 * NSEC_PER_MSEC);
 	dispatch_after(time, dispatch_get_main_queue(), ^(void){
 		[layer setNeedsDisplayInRect:r];
 	});


### PR DESCRIPTION
The immediate display of the screen sometimes miss the update from
the CPU side memory.  No obvious synchronization mechanism is available.
In order to make sure the screen updates properly, we set needsDisplay
again after a minimal delay to ensure a second screen update.

Fix #268 for the time being and I will see if I can fix it properly.