### PR TITLE
9c, 9l: use $TMPDIR if available

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -133,7 +133,7 @@ case "$tag" in
 esac
 
 # N.B. Must use temp file to avoid pipe; pipe loses status.
-xtmp=/tmp/9c.$$.$USER.out
+xtmp=${TMPDIR-/tmp}/9c.$$.$USER.out
 $cc -DPLAN9PORT -I$PLAN9/include $cflags "$@" 2>$xtmp
 status=$?
 quiet $xtmp

--- a/bin/9l
+++ b/bin/9l
@@ -346,7 +346,7 @@ then
 	echo $ld -L$PLAN9/lib "$@" $libsl $extralibs $frameworks
 fi
 
-xtmp=/tmp/9l.$$.$USER.out
+xtmp="${TMPDIR-/tmp}/9l.$$.$USER.out"
 xxout() {
 	sed 's/.*: In function `[^:]*: *//' $xtmp | egrep . | 
 	egrep -v 'is (often|almost always) misused|is dangerous, better use|text-based stub' 


### PR DESCRIPTION
NixOS sandboxed builds (at least on Mac) don't have access to /tmp,
and this should be better POSIX.