### PR TITLE
devdraw: use CoreFoundation explicitly

### DIFF
--- a/src/cmd/devdraw/cocoa-screen.m
+++ b/src/cmd/devdraw/cocoa-screen.m
@@ -56,6 +56,7 @@
 #endif
 
 AUTOFRAMEWORK(Cocoa)
+AUTOFRAMEWORK(CoreFoundation)
 
 #define LOG	if(0)NSLog
 #define panic	sysfatal


### PR DESCRIPTION
Why?  Not sure, but something about Nix's build environment
wants this here.