### PR TITLE
9l: support Linux version 5.0+

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -40,7 +40,7 @@ case "$tag" in
 	userpath=true
 	extralibs="$extralibs -lutil -lresolv"
 	case "${SYSVERSION:-`uname -r`}" in
-	2.6.* | 3.* | 4.*)
+	2.6.* | 3.* | 4.* | 5.*)
 		extralibs="$extralibs -lpthread"
 		;;
 	esac

--- a/bin/9l
+++ b/bin/9l
@@ -40,7 +40,7 @@ case "$tag" in
 	userpath=true
 	extralibs="$extralibs -lutil -lresolv"
 	case "${SYSVERSION:-`uname -r`}" in
-	2.6.* | 3.* | 4.* | 5.*)
+	2.6.* | [3-9].* | [1-9][0-9].*)
 		extralibs="$extralibs -lpthread"
 		;;
 	esac


### PR DESCRIPTION
I'm using a slightly non-head version on plan9port here, but I needed this change to compile and link programs.

I think the real credit for this change goes to W.F. Cody who documented it on this forum entry:
https://bbs.archlinux.org/viewtopic.php?pid=1119508#p1119508
