### PR TITLE
acme: show Get command not only for dirs' windows

### DIFF
--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -495,10 +495,8 @@ winsettag1(Window *w)
 			i += 4;
 		}
 	}
-	if(w->isdir){
-		runemove(new+i, Lget, 4);
-		i += 4;
-	}
+	runemove(new+i, Lget, 4);
+	i += 4;
 	runemove(new+i, Lpipe, 2);
 	i += 2;
 	r = runestrchr(old, '|');


### PR DESCRIPTION
Handy to have Get command always available for files, especially after `go fmt`.