### PR TITLE
hoc: don't nest calls to follow() when lexing ++/+= and --/-=

### DIFF
--- a/src/cmd/hoc/hoc.y
+++ b/src/cmd/hoc/hoc.y
@@ -215,8 +215,8 @@ yylex(void)		/* hoc6 */
 		return STRING;
 	}
 	switch (c) {
-	case '+':	return follow('+', INC, follow('=', ADDEQ, '+'));
-	case '-':	return follow('-', DEC, follow('=', SUBEQ, '-'));
+	case '+':	return follow('+', INC, '+') == INC ? INC : follow('=', ADDEQ, '+');
+	case '-':	return follow('-', DEC, '-') == DEC ? DEC : follow('=', SUBEQ, '-');
 	case '*':	return follow('=', MULEQ, '*');
 	case '/':	return follow('=', DIVEQ, '/');
 	case '%':	return follow('=', MODEQ, '%');


### PR DESCRIPTION
The code had a nested use of the follow() function that could cause +=+
and -=- to register as ++ and --.  The first follow() to execute could
consume a character and match and then the second follow() could consume
another character and match.  For example i-=-10 would result in a syntax
error and i-=- would decrement i.