### PR TITLE
plumber: add -f (foreground) option

### DIFF
--- a/man/man4/plumber.4
+++ b/man/man4/plumber.4
@@ -4,6 +4,9 @@ plumber \- file system for interprocess messaging
 .SH SYNOPSIS
 .B plumber
 [
+.B -f
+]
+[
 .B -p
 .I plumbing
 ]
@@ -23,7 +26,7 @@ in the format of
 Its services are posted via
 .IR 9pserve (4)
 as
-.BR plumb .
+.BR plumb ,
 and consist of two
 pre-defined files,
 .B plumb/send
@@ -95,6 +98,10 @@ Thus the rule set may be edited dynamically with a traditional text editor.
 However, ports are never deleted dynamically; if a new set of rules does not
 include a port that was defined in earlier rules, that port will still exist (although
 no new messages will be delivered there).
+.PP
+The
+.B -f
+option causes the process to run in the foreground.
 .SH FILES
 .TF $HOME/lib/plumbing
 .TP

--- a/src/cmd/plumb/fsys.c
+++ b/src/cmd/plumb/fsys.c
@@ -186,7 +186,7 @@ getclock(void)
 }
 
 void
-startfsys(void)
+startfsys(int foreground)
 {
 	int p[2];
 
@@ -199,7 +199,10 @@ startfsys(void)
 	if(post9pservice(p[1], "plumb", nil) < 0)
 		sysfatal("post9pservice plumb: %r");
 	close(p[1]);
-	proccreate(fsysproc, nil, Stack);
+	if(foreground)
+		fsysproc(nil);
+	else
+		proccreate(fsysproc, nil, Stack);
 }
 
 static void

--- a/src/cmd/plumb/plumber.c
+++ b/src/cmd/plumb/plumber.c
@@ -7,6 +7,7 @@
 #include "plumber.h"
 
 int debug;
+int foreground=0;
 char	*plumbfile;
 char *user;
 char *home;
@@ -36,6 +37,9 @@ threadmain(int argc, char *argv[])
 	ARGBEGIN{
 	case 'd':
 		debug = 1;
+		break;
+	case 'f':
+		foreground = 1;
 		break;
 	case 'p':
 		plumbfile = ARGF();
@@ -69,7 +73,7 @@ threadmain(int argc, char *argv[])
 	 */
 	printerrors = 0;
 	makeports(rules);
-	startfsys();
+	startfsys(foreground);
 	threadexits(nil);
 }
 

--- a/src/cmd/plumb/plumber.h
+++ b/src/cmd/plumb/plumber.h
@@ -72,7 +72,7 @@ void*	emalloc(long);
 void*	erealloc(void*, long);
 char*	estrdup(char*);
 Ruleset**	readrules(char*, int);
-void		startfsys(void);
+void		startfsys(int);
 Exec*	matchruleset(Plumbmsg*, Ruleset*);
 void		freeexec(Exec*);
 char*	startup(Ruleset*, Exec*);


### PR DESCRIPTION
In MacOS, services run by launchd must run in the foreground, since
launchd manages forking and other resources.