### PR TITLE
page: fix hang for forward-only postscript files

### DIFF
--- a/src/cmd/page/cache.c
+++ b/src/cmd/page/cache.c
@@ -168,7 +168,12 @@ raproc(void *a)
 	
 	c = a;
 	lockdisplay(display);
-	_cachedpage(c->doc, c->angle, c->page, "-ra");
+	/*
+	 * If there is only one page in a fwdonly file, we may reach EOF
+	 * while doing readahead and page will exit without showing anything.
+	 */
+	if(!c->doc->fwdonly)
+		_cachedpage(c->doc, c->angle, c->page, "-ra");
 	rabusy = 0;
 	unlockdisplay(display);
 	free(c);

--- a/src/cmd/page/ps.c
+++ b/src/cmd/page/ps.c
@@ -355,6 +355,7 @@ Keepreading:
 	if(dumb) {
 		fprint(ps->gs.gsfd, "(%s) run PAGEFLUSH\n", argv[0]);
 		fprint(ps->gs.gsfd, "(/dev/fd/3) (w) file dup (THIS IS NOT A PLAN9 BITMAP 01234567890123456789012345678901234567890123456789\\n) writestring flushfile\n");
+		close(ps->gs.gsfd);
 	}
 
 	ps->bbox = bbox;


### PR DESCRIPTION
Page was hanging because ghostscript never closes the fd from which
we're reading BMP data. We close our end of the pipe so that ghostscript
will close its end.

Tested with ghostscript version 9.50.

Fixes #124