### PR TITLE
page: fix pdf prolog for ghostscript >= 9.27

### DIFF
--- a/src/cmd/page/pdfprolog.c
+++ b/src/cmd/page/pdfprolog.c
@@ -16,5 +16,4 @@
 "  } if\n"
 "} bind def\n"
 "\n"
-"GS_PDF_ProcSet begin\n"
-"pdfdict begin\n"
+"runpdfbegin\n"

--- a/src/cmd/page/pdfprolog.ps
+++ b/src/cmd/page/pdfprolog.ps
@@ -16,5 +16,4 @@
   } if
 } bind def
 
-GS_PDF_ProcSet begin
-pdfdict begin
+runpdfbegin


### PR DESCRIPTION
Ghostscript 9.27 removed GS_PDF_ProcSet and pdfdict due to a security
issue (see https://security-tracker.debian.org/tracker/CVE-2019-3839).

This fix was contributed by @onyxperidot (see #279).

Fixes #279