### PR TITLE
9term: add a "look" menu item

### DIFF
--- a/man/man1/9term.1
+++ b/man/man1/9term.1
@@ -285,6 +285,13 @@ containing the selection (typing cursor).
 A typical use of this feature is to tell the editor to find the source of an error
 by plumbing the file and line information in a compiler's diagnostic.
 .PP
+The
+.B look
+menu item searches forward for the contents of the selection within
+the window. If a match is found, it becomes the new selection and the
+window scrolls to display it. The search wraps around to the beginning
+of the windows if the end of the window is reached.
+.PP
 For systems without a three-button mouse, the keyboard modifier
 keys can be used to modify the effect of the main mouse button.
 On Unix systems, the Control key changes the main button to button 2,

--- a/src/cmd/9term/9term.c
+++ b/src/cmd/9term/9term.c
@@ -288,6 +288,7 @@ enum
 	Paste,
 	Snarf,
 	Plumb,
+	Look,
 	Send,
 	Scroll,
 	Cook
@@ -298,6 +299,7 @@ char		*menu2str[] = {
 	"paste",
 	"snarf",
 	"plumb",
+	"look",
 	"send",
 	"cook",
 	"scroll",
@@ -346,6 +348,10 @@ button2menu(Window *w)
 
 	case Plumb:
 		wplumb(w);
+		break;
+
+	case Look:
+		wlook(w);
 		break;
 
 	case Send:

--- a/src/cmd/9term/dat.h
+++ b/src/cmd/9term/dat.h
@@ -177,6 +177,7 @@ void		wmousectl(Window*);
 void		wmovemouse(Window*, Point);
 void		wpaste(Window*);
 void		wplumb(Window*);
+void		wlook(Window*);
 void		wrefresh(Window*, Rectangle);
 void		wrepaint(Window*);
 void		wresize(Window*, Image*, int);

--- a/src/cmd/9term/wind.c
+++ b/src/cmd/9term/wind.c
@@ -907,6 +907,31 @@ winborder(Window *w, Point xy)
 }
 
 void
+wlook(Window *w)
+{
+	int i, n, e;
+
+	i = w->q1;
+	n = i - w->q0;
+	e = w->nr - n;
+	if(n <= 0 || e < n)
+		return;
+
+	if(i > e)
+		i = 0;
+
+	while(runestrncmp(w->r+w->q0, w->r+i, n) != 0){
+		if(i < e)
+			i++;
+		else
+			i = 0;
+	}
+
+	wsetselect(w, i, i+n);
+	wshow(w, i);
+}
+
+void
 wmousectl(Window *w)
 {
 	int but;


### PR DESCRIPTION
Add a menu item which functions similar to acme's `Look` command.

This is copied from 9front. See:
https://code.9front.org/hg/plan9front/rev/1f1596dbca51
https://code.9front.org/hg/plan9front/rev/d2de1d2f7b48