### PR TITLE
ed: replace magic number usage (temp file size fix).

### DIFF
--- a/src/cmd/ed.c
+++ b/src/cmd/ed.c
@@ -1050,7 +1050,7 @@ putline(void)
 		}
 	}
 	nl = tline;
-	tline += ((lp-linebuf) + 03) & 077776;
+	tline += ((lp-linebuf) + 03) & (NBLK-1);
 	return nl;
 }
 


### PR DESCRIPTION
Temp file size is now declared in an enum; changing it from the default introduces a subtle bug in `putline`, which expects 32767.

Mask with `NBLK-1` instead.