### PR TITLE
ed: formatting tweak (remove redundant tab).

### DIFF
--- a/src/cmd/ed.c
+++ b/src/cmd/ed.c
@@ -13,7 +13,7 @@ enum
 	FNSIZE	= 128,		/* file name */
 	LBSIZE	= 4096,		/* max line size */
 	BLKSIZE	= 4096,		/* block size in temp file */
-	NBLK	= 32767,		/* max size of temp file */
+	NBLK	= 32767,	/* max size of temp file */
 	ESIZE	= 256,		/* max size of reg exp */
 	GBSIZE	= 256,		/* max size of global command */
 	MAXSUB	= 9,		/* max number of sub reg exp */


### PR DESCRIPTION
Given that tabs are being used for comment alignment (compare `ESCFLG` which uses a single `\t` to `FNSIZE` which uses two), remove one of the tabs separating `NBLK` from its comment.

With this change, `enum` comments are aligned when tabs are rendered as 4 or 8 spaces. (With 2 or 6, they're already misaligned.)

Alternatively, spaces could be used here instead, though that would not be in keeping with the file's (venerable!) style.