### PR TITLE
INSTALL, 9c, 9l: improve handling of *BSD

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -29,6 +29,30 @@ case `uname` in
 SunOS)
 	awk=nawk
 	;;
+DragonFly|*BSD)
+	case `cc -v 2>&1` in
+	*clang*)
+		echo "CC9=clang" >> $PLAN9/config
+		;;
+	*gcc*)
+		echo "CC9=gcc" >> $PLAN9/config
+		;;
+	esac
+	echo "* Running on" `uname`", adjusting linker flags"
+	case `uname` in
+	OpenBSD)
+		echo "LDFLAGS='-L/usr/X11R6/lib -pthread'" >> $PLAN9/config
+		;;
+	NetBSD)
+		echo "LDFLAGS='-L/usr/X11R7/lib -pthread'" >> $PLAN9/config
+		;;
+	*)
+		echo "LDFLAGS='-L/usr/local/lib -pthread'" >> $PLAN9/config
+		;;
+	esac
+	echo "CFLAGS='-pthread'" >> $PLAN9/config
+	awk=awk
+	;;
 *)
 	awk=awk
 	;;
@@ -42,29 +66,6 @@ echo "* Resetting $PLAN9/config"
 rm -f config
 
 (
-if [ `uname` = FreeBSD ]; then
-	case `cc -v 2>&1` in
-	*clang*)
-		echo "CC9=clang" >> $PLAN9/config
-		;;
-	*)
-		;;
-	esac
-	echo "* Running on FreeBSD, adjusting linker flags"
-	echo "LDFLAGS='-L/usr/local/lib'" >> $PLAN9/config
-fi
-
-if [ `uname` = DragonFly ]; then
-	echo "* Running on DragonFly BSD, adjusting linker flags"
-	echo "LDFLAGS='-L/usr/local/lib -pthread'" >> $PLAN9/config
-	echo "CFLAGS='-pthread'" >> $PLAN9/config
-fi
-
-if [ `uname` = OpenBSD ]; then
-	echo "* Running on OpenBSD, adjusting linker flags"
-	echo "LDFLAGS='-L/usr/X11R6/lib -pthread'" >> $PLAN9/config
-fi
-
 if [ `uname` = Linux ]; then
 	# On Linux, we use the kernel version to decide whether
 	# to use pthreads or not.  On 2.6 versions that aren't
@@ -135,6 +136,7 @@ if [ `uname` != Darwin ]; then
 	# Determine whether fontsrv X11 files are available.
 	rm -f a.out
 	cc -o a.out -c -Iinclude -I/usr/include -I/usr/local/include -I/usr/include/freetype2 -I/usr/local/include/freetype2 \
+	    -I/usr/X11R7/include -I/usr/X11R7/include/freetype2 \
 	    -I/usr/X11R6/include -I/usr/X11R6/include/freetype2 src/cmd/fontsrv/x11.c >/dev/null 2>&1
 	if [ -f a.out ]; then
 		echo "	fontsrv dependencies found."

--- a/bin/9c
+++ b/bin/9c
@@ -79,9 +79,8 @@ useclang()
 
 tag="${SYSNAME:-`uname`}-${OBJTYPE:-`uname -m`}-${CC9:-cc}"
 case "$tag" in
-*FreeBSD*gcc*)	usegcc ;;
-*FreeBSD*clang*)	useclang ;;
-*DragonFly*|*BSD*)	usegcc ;;
+*(DragonFly|BSD)*gcc*)	usegcc ;;
+*(DragonFly|BSD)*clang*)	useclang ;;
 *Darwin-x86_64*)
 		useclang
 		cflags="$ngflags -g3 -m64"

--- a/bin/9l
+++ b/bin/9l
@@ -11,19 +11,6 @@ nmflags=""
 extralibs="-lm"
 tag="${SYSNAME:-`uname`}-${OBJTYPE:-`uname -m`}"
 case "$tag" in
-*FreeBSD*)
-	ld=${CC9:-gcc}
-	userpath=true
-	extralibs="$extralibs -lutil"
-	case "`uname -r`" in
-	5.2.*)
-		extralibs="$extralibs -lkse"
-		;;
-	[5-9].*|1[0-9].*)
-		extralibs="$extralibs -lpthread"
-		;;
-	esac
-	;;
 *DragonFly*|*BSD*)
 	ld=${CC9:-gcc}
 	userpath=true


### PR DESCRIPTION
note that I can only be sure this will work at OpenBSD and DragonFly BSD, however it shouldn't fail at FreeBSD (it will fail, FreeBSD always fails me) and NetBSD (does plan9port build at NetBSD anyway?)