### PR TITLE
cmd/htmlroff: fix buffer overflow in t2.c getqarg

### DIFF
--- a/src/cmd/htmlroff/t2.c
+++ b/src/cmd/htmlroff/t2.c
@@ -26,7 +26,7 @@ getqarg(void)
 	Rune *p, *e;
 	
 	p = buf;
-	e = p+sizeof buf-1;
+	e = p + nelem(buf) - 1;
 	
 	if(getrune() != '\'')
 		return nil;


### PR DESCRIPTION
This is actually from 2016:
https://plan9port-review.googlesource.com/c/plan9/+/1590

Change-Id: I6f2a3d71a9dd589eff7ab15b3c1d3997254b3c35