### PR TITLE
cb: fix a null pointer dereference

### DIFF
--- a/src/cmd/cb/cb.c
+++ b/src/cmd/cb/cb.c
@@ -29,7 +29,7 @@ main(int argc, char *argv[])
 			maxleng -= (maxleng + 5)/10;
 			continue;
 		default:
-			fprint(2, "cb: illegal option %c\n", *argv[1]);
+			fprint(2, "cb: illegal option %c\n", (*argv)[1]);
 			exits("boom");
 		}
 	}
@@ -354,7 +354,7 @@ work(void){
 					continue;
 				}
 			}
-			else if (lbegin == 0 || p > string) 
+			else if (lbegin == 0 || p > string)
 				if(strict)
 					putch(c,NO);
 				else putch(c,YES);
@@ -969,7 +969,7 @@ cont:
 					if(nlct++ > 2)goto done;
 			}
 			puttmp(c,1);
-	star:
+star:
 			if(puttmp((c=Bgetc(input)),1) == '/'){
 				beg = tp;
 				puttmp((c=Bgetc(input)),1);


### PR DESCRIPTION
Just added a pair of parentheses. I also ran cb on cb.c to beautify the
code.

This is actually on Gerrit from 2016:
https://plan9port-review.googlesource.com/c/plan9/+/1574

Change-Id: I5e234adba0f95c13d6eecb121bf11bba4bf54566