### PR TITLE
ls: check that pointer is not nil before calling qsort

### DIFF
--- a/src/cmd/ls.c
+++ b/src/cmd/ls.c
@@ -143,7 +143,7 @@ output(void)
 	char buf[4096];
 	char *s;
 
-	if(!nflag)
+	if(!nflag && dirbuf!=0)
 		qsort(dirbuf, ndir, sizeof dirbuf[0], (int (*)(const void*, const void*))compar);
 	for(i=0; i<ndir; i++)
 		dowidths(dirbuf[i].d);


### PR DESCRIPTION
Passing a null pointer to qsort is an error in C (GCC and Clang agree
with the standards there, so this is no joke).

Change-Id: Ia2b015793a75ea4e85ae8f47da6beead9c4290e6