### PR TITLE
acme: do not pass null pointers where disallowed

### DIFF
--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -276,6 +276,8 @@ runeeq(Rune *s1, uint n1, Rune *s2, uint n2)
 {
 	if(n1 != n2)
 		return FALSE;
+	if(n1 == 0)
+		return TRUE;
 	return memcmp(s1, s2, n1*sizeof(Rune)) == 0;
 }
 

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -476,7 +476,8 @@ winsettag1(Window *w)
 	/* compute the text for the whole tag, replacing current only if it differs */
 	new = runemalloc(w->body.file->nname+100);
 	i = 0;
-	runemove(new+i, w->body.file->name, w->body.file->nname);
+	if(w->body.file->nname != 0)
+		runemove(new, w->body.file->name, w->body.file->nname);
 	i += w->body.file->nname;
 	runemove(new+i, Ldelsnarf, 10);
 	i += 10;


### PR DESCRIPTION
The C standards disallow passing null pointers to memmove and memcmp.

Change-Id: I1c88c2adbc32a23ef742f206038b8f7c4e0540c7