### PR TITLE
9c: enable nonstandard features used by plan9port

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -15,6 +15,7 @@ usegcc()
 		-Wno-sign-compare \
 		-Wno-unknown-pragmas \
 		-fno-omit-frame-pointer \
+		-fno-strict-aliasing \
 		-fsigned-char \
 	"
 	# want to put -fno-optimize-sibling-calls here but
@@ -71,8 +72,9 @@ useclang()
 		-Wno-gnu-designator \
 		-Wno-array-bounds \
 		-Wno-unneeded-internal-declaration \
-		-fsigned-char \
 		-fno-caret-diagnostics \
+		-fno-strict-aliasing \
+		-fsigned-char \
 	"
 	cflags="$ngflags -g"
 }


### PR DESCRIPTION
The p9p codebase pervasively violates the ANSI and ISO C aliasing rules,
according to which objects may not be accessed through pointers of a
different type, with some exceptions such as (un/signed) char being able
to access any value and a structure and its first member being
interchangeable.
To enable compiler support for the nonstandard aliasing (type punning
wihout unions), the -fno-strict-aliasing flag is needed.

Some aliasing references:
https://blog.regehr.org/archives/959
https://blog.regehr.org/archives/1307
http://dbp-consulting.com/tutorials/StrictAliasing.html
and see the -fstrict-aliasing entry in the GCC manual.

This commit has actually been sitting on the p9p Gerrit since 2016:
https://plan9port-review.googlesource.com/c/plan9/+/1600

Updates #313