### PR TITLE
mk: clean up symtab.c, fix hash

### DIFF
--- a/src/cmd/mk/symtab.c
+++ b/src/cmd/mk/symtab.c
@@ -1,7 +1,7 @@
 #include	"mk.h"
 
 #define	NHASH	4099
-#define	HASHMUL	79L	/* this is a good value */
+#define	HASHMUL	79UL	/* this is a good value */
 static Symtab *hash[NHASH];
 
 void
@@ -21,14 +21,12 @@ syminit(void)
 Symtab *
 symlook(char *sym, int space, void *install)
 {
-	long h;
+	ulong h;
 	char *p;
 	Symtab *s;
 
 	for(p = sym, h = space; *p; h += *p++)
 		h *= HASHMUL;
-	if(h < 0)
-		h = ~h;
 	h %= NHASH;
 	for(s = hash[h]; s; s = s->next)
 		if((s->space == space) && (strcmp(s->name, sym) == 0))
@@ -47,7 +45,7 @@ symlook(char *sym, int space, void *install)
 void
 symdel(char *sym, int space)
 {
-	long h;
+	ulong h;
 	char *p;
 	Symtab *s, *ls;
 
@@ -55,8 +53,6 @@ symdel(char *sym, int space)
 
 	for(p = sym, h = space; *p; h += *p++)
 		h *= HASHMUL;
-	if(h < 0)
-		h = ~h;
 	h %= NHASH;
 	for(s = hash[h], ls = 0; s; ls = s, s = s->next)
 		if((s->space == space) && (strcmp(s->name, sym) == 0)){


### PR DESCRIPTION
syminit is only called once in main(), and at that point the global
array hash is still all zeroes, thus the call is a no-op; it gets
optimized out.
symdel and symstat also aren't used anywhere, so they are being removed.

The hash function was abstracted out of symlook and symdel, and changed
so as not to use signed integer overflow because that is forbidden in
standard C.

A version of this commit has actually been sitting on the p9p Gerrit
since 2016:
https://plan9port-review.googlesource.com/c/plan9/+/1572

Updates #313

Change-Id: I5478ae03f208a92a6ba16060486b946dcc4b2cf1