### PR TITLE
all: sync and dedup the creation of the SYSNAME and OBJTYPE env vars

### DIFF
--- a/buildEnvironmentVariables
+++ b/buildEnvironmentVariables
@@ -1,0 +1,19 @@
+SYSNAME=`uname`
+OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
+	s;.*i[3-6]86.*;386;;
+	s;.*i86pc.*;386;;
+	s;.*amd64.*;x86_64;;
+	s;.*x86_64.*;x86_64;;
+	s;.*armv.*;arm;g;
+	s;.*powerpc.*;power;g;
+	s;.*PowerMacintosh.*;power;g;
+	s;.*Power.Macintosh.*;power;g;
+	s;.*macppc.*;power;g;
+	s;.*mips.*;mips;g;
+	s;.*ppc64.*;power;g;
+	s;.*ppc.*;power;g;
+	s;.*alpha.*;alpha;g;
+	s;.*sun4u.*;sun4u;g;
+	s;.*aarch64.*;arm64;
+	s;.*arm64.*;arm64;
+'`

--- a/dist/buildmk
+++ b/dist/buildmk
@@ -1,21 +1,6 @@
 #!/bin/sh
 
 # run this in the src directory
-SYSNAME=`uname` export SYSNAME
-OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
-	s;.*i[3-6]86.*;386;;
-	s;.*i86pc.*;386;;
-	s;.*amd64.*;x86_64;;
-	s;.*x86_64.*;x86_64;;
-	s;.*armv.*;arm;g;
-	s;.*powerpc.*;power;g;
-	s;.*PowerMacintosh.*;power;g;
-	s;.*Power.Macintosh.*;power;g;
-	s;.*macppc.*;power;g;
-	s;.*mips.*;mips;g;
-	s;.*ppc64.*;power;g;
-	s;.*ppc.*;power;g;
-	s;.*alpha.*;alpha;g;
-	s;.*sun4u.*;sun4u;g;
-'` export OBJTYPE
+export SYSNAME OBJTYPE
+. ../buildEnvironmentVariables
 sh -x mkmk.sh

--- a/src/mkhdr
+++ b/src/mkhdr
@@ -1,22 +1,4 @@
-# if you change this, also edit ../dist/buildmk
-SYSNAME=`uname`
-OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
-	s;.*i[3-6]86.*;386;;
-	s;.*i86pc.*;386;;
-	s;.*amd64.*;x86_64;;
-	s;.*x86_64.*;x86_64;;
-	s;.*armv.*;arm;g;
-	s;.*powerpc.*;power;g;
-	s;.*PowerMacintosh.*;power;g;
-	s;.*Power.Macintosh.*;power;g;
-	s;.*macppc.*;power;g;
-	s;.*mips.*;mips;g;
-	s;.*ppc64.*;power;g;
-	s;.*ppc.*;power;g;
-	s;.*alpha.*;alpha;g;
-	s;.*sun4u.*;sun4u;g;
-	s;.*aarch64.*;arm64;
-'`
+<$PLAN9/buildEnvironmentVariables
 
 BIN=$PLAN9/bin
 LIBDIR=$PLAN9/lib


### PR DESCRIPTION
This should prevent the issues of dist/buildmk and src/mkhdr getting out
of synchronization yet again.

I also add a rule for arm64 to the OBJTYPE sed command.

Fixes #243
Fixes #320

Change-Id: I60f69a1f32b5ed5ae5ac8a1659c38e29debed005