### PR TITLE
lib9, libndb: exclude terminating null from strncpy bound

### DIFF
--- a/src/lib9/ctime.c
+++ b/src/lib9/ctime.c
@@ -58,7 +58,7 @@ localtime(long tim)
 
 	if (zonelookuptinfo(&ti, tim)!=-1) {
 		ct = gmtime(tim+ti.tzoff);
-		strncpy(ct->zone, ti.zone, sizeof ct->zone);
+		strncpy(ct->zone, ti.zone, sizeof ct->zone - 1);
 		ct->zone[sizeof ct->zone-1] = 0;
 		ct->tzoff = ti.tzoff;
 		return ct;

--- a/src/libndb/sysdnsquery.c
+++ b/src/libndb/sysdnsquery.c
@@ -84,7 +84,7 @@ mkptrname(char *ip, char *rip, int rlen)
 static void
 nstrcpy(char *to, char *from, int len)
 {
-	strncpy(to, from, len);
+	strncpy(to, from, len-1);
 	to[len-1] = 0;
 }
 


### PR DESCRIPTION
GCC pointed this out with some "warning: ‘strncpy’ specified bound NUM
equals destination size [-Wstringop-truncation]" warnings.

Change-Id: Id8408b165f6e4ae82c96a77599d89f658d979b32