### PR TITLE
cmd/venti/srv: split memory allocation call

### DIFF
--- a/src/cmd/venti/srv/icache.c
+++ b/src/cmd/venti/srv/icache.c
@@ -68,8 +68,8 @@ mkihash(int size1)
 		size <<= 1;
 	}
 
-	ih = vtmallocz(sizeof(IHash)+size*sizeof(ih->table[0]));
-	ih->table = (IEntry**)(ih+1);
+	ih = vtmallocz(sizeof(IHash));
+	ih->table = vtmallocz(size * sizeof(ih->table[0]));
 	ih->bits = bits;
 	ih->size = size;
 	return ih;


### PR DESCRIPTION
This splits a certain vtmallocz call in mkihash into two vtmallocz
calls. The first issue this fixes is that the C aliasing rules were not
respected in the code before this commit. The other thing is that this
enables better memory alignment guarantees.

Updates #313

Change-Id: Ia4f3e0fc85facc778193f5e977d4f99a1a9abd23