### PR TITLE
9c: Fix case patterns for DragonFly and other BSDs

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -79,8 +79,8 @@ useclang()
 
 tag="${SYSNAME:-`uname`}-${OBJTYPE:-`uname -m`}-${CC9:-cc}"
 case "$tag" in
-*(DragonFly|BSD)*gcc*)	usegcc ;;
-*(DragonFly|BSD)*clang*)	useclang ;;
+*DragonFly*gcc*|*BSD*gcc*)	usegcc ;;
+*DragonFly*clang|*BSD*clang*)	useclang ;;
 *Darwin-x86_64*)
 		useclang
 		cflags="$ngflags -g3 -m64"


### PR DESCRIPTION
POSIX does not support grouping in case item patterns.
Installing with a strict POSIX shell fails with:

    /usr/local/plan9/bin/9c: line 82: syntax error near unexpected token `('
    /usr/local/plan9/bin/9c: line 82: `*(DragonFly|BSD)*gcc*)	usegcc ;;'

This change expands the patterns to work around the limitation.

See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10
(and search for `case_clause`)