### PR TITLE
ACME: Support editing file names with spaces

### DIFF
--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -107,6 +107,8 @@ The tag contains a number of
 blank-separated words, followed by a vertical bar character, followed by anything.
 The first word is the name of the window, typically the name of the associated
 file or directory, and the other words are commands available in that window.
+The file name is separated from all other words in the tag by a tabulator character
+to allow editing of files with spaces in their name or path.
 Any text may be added after the bar; examples are strings to search for or
 commands to execute in that window.
 Changes to the text left of the bar will be ignored,

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -497,7 +497,7 @@ dirname(Text *t, Rune *r, int n)
 		c = b[m];
 		if(c == '/')
 			slash = m;
-		if(c==' ' || c=='\t')
+		if(c=='\t')
 			break;
 	}
 	if(slash < 0)
@@ -612,7 +612,7 @@ expandfile(Text *t, uint q0, uint q1, Expand *e)
 	if(nname == -1)
 		nname = n;
 	for(i=0; i<nname; i++)
-		if(!isfilec(r[i]))
+		if(!isfilec(r[i]) && r[i] != ' ')
 			goto Isntfile;
 	/*
 	 * See if it's a file name in <>, and turn that into an include

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -446,7 +446,7 @@ winsettag1(Window *w)
 	int i, j, k, n, bar, dirty, resize;
 	Rune *new, *old, *r;
 	uint q0, q1;
-	static Rune Ldelsnarf[] = { ' ', 'D', 'e', 'l', ' ',
+	static Rune Ldelsnarf[] = { '\t', 'D', 'e', 'l', ' ',
 		'S', 'n', 'a', 'r', 'f', 0 };
 	static Rune Lundo[] = { ' ', 'U', 'n', 'd', 'o', 0 };
 	static Rune Lredo[] = { ' ', 'R', 'e', 'd', 'o', 0 };
@@ -587,7 +587,7 @@ wincommit(Window *w, Text *t)
 	r = runemalloc(w->tag.file->b.nc);
 	bufread(&w->tag.file->b, 0, r, w->tag.file->b.nc);
 	for(i=0; i<w->tag.file->b.nc; i++)
-		if(r[i]==' ' || r[i]=='\t')
+		if (r[i]=='\t')
 			break;
 	if(runeeq(r, i, w->body.file->name, w->body.file->nname) == FALSE){
 		seq++;


### PR DESCRIPTION
Hi,

this PR is a fix for #26. It works mainly by tweaking the logic that decides which part of the tag of a window is the file name:

Everything up to the first tab character in the tag is now considered a file name

Visually, the difference is relatively minor. It takes a bit getting used to the blank space between the file name and the `Del`, but apart from that it seems to do the job.

I've been using this patch for a while and haven't observed negative side effects yet.