### PR TITLE
acme: allow spaces in window names

### DIFF
--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -610,7 +610,7 @@ expandfile(Text *t, uint q0, uint q1, Expand *e)
 	if(nname == -1)
 		nname = n;
 	for(i=0; i<nname; i++)
-		if(!isfilec(r[i]))
+		if(!isfilec(r[i]) && r[i] != ' ')
 			goto Isntfile;
 	/*
 	 * See if it's a file name in <>, and turn that into an include

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -439,16 +439,31 @@ wincleartag(Window *w)
 Rune*
 parsetag(Window *w, int *len)
 {
+	static Rune Ldelsnarf[] = { ' ', 'D', 'e', 'l', ' ', 'S', 'n', 'a', 'r', 'f', 0 };
+	static Rune Lspacepipe[] = { ' ', '|', 0 };
+	static Rune Ltabpipe[] = { ' ', '|', 0 };
 	int i;
-	Rune *r;
+	Rune *r, *p, *pipe;
 
 	r = runemalloc(w->tag.file->b.nc+1);
 	bufread(&w->tag.file->b, 0, r, w->tag.file->b.nc);
 	r[w->tag.file->b.nc] = '\0';
 
-	for(i=0; i<w->tag.file->b.nc; i++)
-		if(r[i]==' ' || r[i]=='\t')
-			break;
+	/*
+	 * " |" or "\t|" ends left half of tag
+	 * If we find " Del Snarf" in the left half of the tag
+	 * (before the pipe), that ends the file name.
+	 */
+	pipe = runestrstr(r, Lspacepipe);
+	if((p = runestrstr(r, Ltabpipe)) != nil && (pipe == nil || p < pipe))
+		pipe = p;
+	if((p = runestrstr(r, Ldelsnarf)) != nil && (pipe == nil || p < pipe))
+		i = p - r;
+	else {
+		for(i=0; i<w->tag.file->b.nc; i++)
+			if(r[i]==' ' || r[i]=='\t')
+				break;
+	}
 	*len = i;
 	return r;
 }


### PR DESCRIPTION
There are many things we could do to make this work.
an environment variable to control the character.
Another option would be to use U+00A0 (non-breaking space),
which renders the same as space.

This change avoids changing the separator character and instead
assumes that if the left side of the tag already ends in " Del Snarf |"
then what comes before that is the file name.
Acme already aggressively preserves the "Del Snarf |",
so this should work decently well as a stop-gap.
We can always try something else later.

Fixes #26.
Fixes #104.
Fixes #329.