### PR TITLE
troff: fix missing soelim

### DIFF
--- a/bin/soelim
+++ b/bin/soelim
@@ -1,0 +1,16 @@
+#!/usr/local/plan9/bin/rc
+# joyless reimplementation of soelim
+# the $0 recursion is a bit ugly
+
+# canonicalise troff commands first with sed into ". so file" form.
+# but the space after the dot has to come out; tbl can't cope with it.
+# friggin' html macros can be longer than two characters; grrr.
+sed '/^[.'']/{
+	s/([^\\])\\".*$/\1/
+#	s/^(.)[	 ]*([^	 \\][^	 \\])[	 ]*/\1 \2 /
+	s/^(.)[	 ]*([^	 \\][^	 \\])/\1 \2/
+}' $* | awk '	BEGIN { me = "'$0'" }
+		$1 !~ /^[.'']$/	{ print; next }
+		$2 == "so" { system(me " " $3) ; next }
+		$2 == "nx" { system(me " " $3) ; exit }
+		{ print }' | sed 's/^([.'']) /\1/'

--- a/lib/moveplan9.files
+++ b/lib/moveplan9.files
@@ -17,6 +17,7 @@ bin/netfilestat
 bin/quote1
 bin/quote2
 bin/sig
+bin/soelim
 bin/spell
 bin/src
 bin/ssam

--- a/man/man1/soelim.1
+++ b/man/man1/soelim.1
@@ -1,0 +1,30 @@
+.TH SOELIM 1
+.\" .so in the NAME line confuses the ptx machinery; sorry
+.SH NAME
+soelim \- preprocess so inclusion commands in troff input 
+.SH SYNOPSIS
+.B soelim
+[
+.I files ...
+]
+.SH DESCRIPTION
+.I Soelim
+reads the specified files or the standard input and performs
+the textual inclusion implied by
+.IR troff (1)
+directives of the form
+.sp
+.ti +2m
+.B "\&.so some_file
+.sp
+when they appear at the beginning of input lines.  This is useful when
+using programs such as
+.IR tbl (1)
+that do not normally do this, allowing
+placement of individual tables or other text objects in separate files
+to be run as a part of a large document.
+.SH SOURCE
+.B /rc/bin/soelim
+.SH "SEE ALSO"
+.IR deroff (1),
+.IR troff (1)

--- a/man/man1/soelim.1
+++ b/man/man1/soelim.1
@@ -13,10 +13,9 @@ reads the specified files or the standard input and performs
 the textual inclusion implied by
 .IR troff (1)
 directives of the form
-.sp
-.ti +2m
+.TP
 .B "\&.so some_file
-.sp
+.PP
 when they appear at the beginning of input lines.  This is useful when
 using programs such as
 .IR tbl (1)
@@ -24,7 +23,7 @@ that do not normally do this, allowing
 placement of individual tables or other text objects in separate files
 to be run as a part of a large document.
 .SH SOURCE
-.B /rc/bin/soelim
+.B \*9/bin/soelim
 .SH "SEE ALSO"
 .IR deroff (1),
 .IR troff (1)


### PR DESCRIPTION
The troff `.so` preprocessor `soelim` is missing. It is essential for any troff workflow beyond individual manpages.

In Plan9 it was rewritten as an rc script (like man) and located in `/rc/bin.` It seems not have made the transition into plan9port.

This pull request (1) imports the Plan9 rc script into `bin/` and fixes the `#!` line to conform to plan9port expectations; (2) adds an entry into `lib/moveplan9.files` to trigger the `/usr/local/plan9` pathname relocation during `INSTALL;` and (3) imports the Plan9 `soelim.1` manpage with some light-touch fixes for plan9port style (mainly adding the `\*9` macro in the SOURCE section and removing hard-coded spacing requests).

The tears-of-frustration comments in the script are the original ones. I have left them untouched, as a mark of respect for the original author's pain...