### PR TITLE
libthread: remove adjustments to stack pointer/size

### DIFF
--- a/src/libthread/thread.c
+++ b/src/libthread/thread.c
@@ -137,9 +137,8 @@ threadalloc(void (*fn)(void*), void *arg, uint stack)
 //print("makecontext sp=%p t=%p startfn=%p\n", (char*)t->stk+t->stksize, t, t->startfn);
 
 	/* call makecontext to do the real work. */
-	/* leave a few words open on both ends */
-	t->context.uc.uc_stack.ss_sp = (void*)(t->stk+8);
-	t->context.uc.uc_stack.ss_size = t->stksize-64;
+	t->context.uc.uc_stack.ss_sp = t->stk;
+	t->context.uc.uc_stack.ss_size = t->stksize;
 #if defined(__sun__) && !defined(__MAKECONTEXT_V2_SOURCE)		/* sigh */
 	/* can avoid this with __MAKECONTEXT_V2_SOURCE but only on SunOS 5.9 */
 	t->context.uc.uc_stack.ss_sp =


### PR DESCRIPTION
When setting the stack pointer and size in the
ucontext structure when creating a thread, the
stack pointer was offset by 8 bytes and the size
was 64 less than allocated.  This appears to be
debugging code from some time ago, but I couldn't
quite figure out what it's purpose was (perhaps
poisoning the top/bottom of the stack to detect
under/overflow?).  The 8-byte offset for the
stack pointer, in particular, was causing instructions
like `MOVAPS` to fail on some platforms: the ABI
assums 16-byte stack alignment on entry to a
function.

Anyway, remove the adjustments.

Fixes #109