### PR TITLE
devdraw: fix `cmd-r` to toggle retina vs. non-retina mode on macOS

### DIFF
--- a/src/cmd/devdraw/mac-screen.m
+++ b/src/cmd/devdraw/mac-screen.m
@@ -510,7 +510,7 @@ void
 rpc_resizeimg(Client *c)
 {
 	DrawView *view = (__bridge DrawView*)c->view;
-	dispatch_sync(dispatch_get_main_queue(), ^(void){
+	dispatch_async(dispatch_get_main_queue(), ^(void){
 		[view resizeimg];
 	});
 }


### PR DESCRIPTION
and not quit an application unexpectedly