### PR TITLE
scale f->originity to match f->height

### DIFF
--- a/src/cmd/fontsrv/x11.c
+++ b/src/cmd/fontsrv/x11.c
@@ -78,7 +78,7 @@ load(XFont *f)
 	}
 	f->unit = face->units_per_EM;
 	f->height = (int)((face->ascender - face->descender) * 1.35);
-	f->originy = face->descender; // bbox.yMin (or descender)  is negative, becase the baseline is y-coord 0
+	f->originy = face->descender * 1.35; // bbox.yMin (or descender)  is negative, because the baseline is y-coord 0
 
 	for(charcode=FT_Get_First_Char(face, &glyph_index); glyph_index != 0;
 		charcode=FT_Get_Next_Char(face, charcode, &glyph_index)) {


### PR DESCRIPTION
Hopefully this fixes the incorrect baseline of fonts in X11 described in #372. The number 1.35 was empirically determined in #111. There should be a better approach ...