### PR TITLE
cmd/9term: use openpty() in NetBSD

### DIFF
--- a/src/cmd/9term/NetBSD.c
+++ b/src/cmd/9term/NetBSD.c
@@ -1,1 +1,17 @@
+#define getpts not_using_this_getpts
 #include "bsdpty.c"
+#undef getpts
+
+#include <util.h>
+
+int
+getpts(int fd[], char *slave)
+{
+	if(openpty(&fd[1], &fd[0], NULL, NULL, NULL) >= 0){
+		fchmod(fd[1], 0620);
+		strcpy(slave, ttyname(fd[0]));
+		return 0;
+	}
+	sysfatal("no ptys: %r");
+	return 0;
+}


### PR DESCRIPTION
This builds on #355. Seems required for 9term (and win inside acme) to work.