### PR TITLE
factotum: plug a memory leak in apop

### DIFF
--- a/src/cmd/auth/factotum/apop.c
+++ b/src/cmd/auth/factotum/apop.c
@@ -129,6 +129,7 @@ apopclient(Conv *c)
 out:
 	keyclose(k);
 	free(chal);
+	free(res);
 	if(c->attr != attr)
 		freeattr(attr);
 	return ret;


### PR DESCRIPTION
It leaks that an allocated memory by *convreadm* when the response is not started with **"bad "**.