### PR TITLE
cmd/rio/winwatch: let initdraw() pick the font if none passed with -f

### DIFF
--- a/man/man1/winwatch.1
+++ b/man/man1/winwatch.1
@@ -13,7 +13,7 @@ winwatch \- monitor rio windows
 .B -n
 ] [
 .B -s
-] 
+]
 .SH DESCRIPTION
 .I Winwatch
 displays the labels of all current
@@ -34,15 +34,25 @@ is given,
 windows matching the regular expression
 .I exclude
 are not shown.
-With the 
+With the
 .B -n
 option,
-the 
+the
 label is defined as the window’s name instead of its class,
 and with
 .B -s
 the labels are sorted by alphabet (case insensitive)
 instead of by order of appearance.
+The
+.B -f
+option can be used to customize the display font.
+If unset, the font choice is deferred to
+.I initdraw
+(see
+.IR graphics(3) ),
+which will try to use the environment variable
+.BR $font
+and fallback to the default font.
 Winwatch is unicode aware.
 .SH EXAMPLE
 Excluding winwatch and stats from being shown.

--- a/src/cmd/rio/winwatch.c
+++ b/src/cmd/rio/winwatch.c
@@ -448,13 +448,12 @@ usage(void)
 void
 main(int argc, char **argv)
 {
-	char *fontname;
+	char *fontname = nil;
 	int Etimer;
 	Event e;
 
 	sortlabels = 0;
 	showwmnames = 0;
-	fontname = "/lib/font/bit/lucsans/unicode.8.font";
 
 	ARGBEGIN {
 	case 'W':
@@ -492,13 +491,10 @@ main(int argc, char **argv)
 	root = DefaultRootWindow(dpy);
 	net_active_window = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
 
-	initdraw(0, 0, "winwatch");
+	initdraw(0, fontname, "winwatch");
 	lightblue = allocimagemix(display, DPalebluegreen, DWhite);
 	if(lightblue==nil)
 		sysfatal("allocimagemix: %r");
-	font = openfont(display, fontname);
-	if(font==nil)
-		sysfatal("font '%s' not found", fontname);
 
 	/* reentry point upon X server errors */
 	setjmp(savebuf);


### PR DESCRIPTION
This way winwatch will honor the $font environment variable.