### PR TITLE
9c: fix for gcc version 10 new common redefinition behaviour

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -20,6 +20,7 @@ usegcc()
 		-Wno-format-truncation \
 		-fno-omit-frame-pointer \
 		-fsigned-char \
+		-fcommon \
 	"
 	# want to put -fno-optimize-sibling-calls here but
 	# that option only works with gcc3+ it seems


### PR DESCRIPTION
Version 10 of `gcc` enforces `-fno-common`, which breaks the build of a number of programs, which in turn forces the `INSTALL` script to fail.

This affects anyone moving to version 10 of `gcc`, which is now the default compiler on (at least) Fedora 32 (just released).

This fix reverts to the pre-10 behaviour by over-riding the (new) default with `-fcommon`.

The real fix is to clean up stray redefinitions which are intended to be declarations...

See [https://gcc.gnu.org/gcc-10/porting_to.html](url)