### PR TITLE
Update AIX support

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -82,6 +82,23 @@ useclang()
 	cflags="$ngflags -g"
 }
 
+usexlc()
+{
+        cc=${CC9:-xlc_r}
+        ngflags=" \
+                -c \
+                -O0 \
+                -qmaxmem=-1 \
+                -qsuppress=1506-236 \
+                -qsuppress=1506-358 \
+                -qsuppress=1500-010 \
+                -qsuppress=1506-224 \
+                -qsuppress=1506-1300 \
+                -qsuppress=1506-342 \
+        "
+        cflags="$ngflags -g -qfullpath"
+}
+
 tag="${SYSNAME:-`uname`}-${OBJTYPE:-`uname -m`}-${CC9:-cc}"
 case "$tag" in
 *DragonFly*gcc*|*BSD*gcc*)	usegcc ;;
@@ -120,7 +137,7 @@ case "$tag" in
 		cflags="$ngflags -g"
 		cflags="$cflags -D__sun__ -D__${s}__"
 		;;
-*AIX*)		usegcc
+*AIX*)		usexlc
 		cflags="$ngflags -g -D__AIX__"
 		;;
 *)

--- a/bin/9l
+++ b/bin/9l
@@ -61,8 +61,9 @@ case "$tag" in
 	esac
 	;;
 *AIX*)
-	ld=${CC9:-gcc}
-	nmflags="-B"
+        ld="${CC9:-xlc_r} -g -O0"
+        nmflags="-A -B"
+        extralibs="$extralibs -lpthread"
 	;;
 *)
 	echo do not know how to link on "$tag" 1>&2
@@ -113,8 +114,8 @@ then
 	then
 		a=`
 			nm $nmflags $ofiles |
-			grep '__p9l_autolib_[a-zA-Z0-9+-]*$' |
-			sed 's/.*__p9l_autolib_//' |
+			grep '__p9l_autolib_[a-zA-Z0-9+-]*' |
+			sed -e 's/.*__p9l_autolib_//' -e 's/:.*//' |
 			sort -u
 		`
 		for i in $a
@@ -144,8 +145,8 @@ then
 			do
 				b=`
 					nm $lpath/lib$i.a 2>/dev/null |
-					grep '__p9l_autolib_[a-zA-Z0-9+-]*$' |
-					sed 's/.*__p9l_autolib_//' |
+					grep '__p9l_autolib_[a-zA-Z0-9+-]*' |
+					sed -e 's/.*__p9l_autolib_//' -e 's/:.*//' |
 					sort -u |
 					egrep -v '^(thread|draw)$'
 				`

--- a/include/u.h
+++ b/include/u.h
@@ -20,7 +20,7 @@ extern "C" {
 #define _NETBSD_SOURCE 1	/* NetBSD */
 #define _SVID_SOURCE 1
 #define _DEFAULT_SOURCE 1
-#if !defined(__APPLE__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__AIX__)
 #	define _XOPEN_SOURCE 1000
 #	define _XOPEN_SOURCE_EXTENDED 1
 #endif
@@ -33,7 +33,7 @@ extern "C" {
 #	define __LONG_LONG_SUPPORTED
 #endif
 #if defined(__AIX__)
-#	define _XOPEN_SOURCE 1
+#	define _XOPEN_SOURCE 600
 #endif
 #if defined(__APPLE__)
 #	define _DARWIN_NO_64_BIT_INODE	/* Snow Leopard */

--- a/src/cmd/9term/AIX.c
+++ b/src/cmd/9term/AIX.c
@@ -1,0 +1,5 @@
+#define _ALL_SOURCE
+
+#define TIOCSCTTY	0x540E
+
+#include "bsdpty.c"

--- a/src/cmd/9term/bsdpty.c
+++ b/src/cmd/9term/bsdpty.c
@@ -5,7 +5,9 @@
 #include <errno.h>
 #include <grp.h>
 #include <termios.h>
+#if !defined(__AIX__)
 #include <sys/termios.h>
+#endif
 #ifdef __linux__
 #include <pty.h>
 #endif

--- a/src/cmd/auxstats/AIX.c
+++ b/src/cmd/auxstats/AIX.c
@@ -1,0 +1,9 @@
+#include <u.h>
+#include <libc.h>
+#include <bio.h>
+#include "dat.h"
+
+void (*statfn[])(int) =
+{
+	0
+};

--- a/src/cmd/draw/mc.c
+++ b/src/cmd/draw/mc.c
@@ -7,9 +7,16 @@
  *	-t suppresses expanding multiple blanks into tabs
  *
  */
+#if defined(__AIX__)
+#define _ALL_SOURCE
+#endif
 #include	<u.h>
 #include	<sys/ioctl.h>
+#if defined(__AIX__)
+#include	<termios.h>
+#else
 #include	<sys/termios.h>
+#endif
 #include	<libc.h>
 #include	<draw.h>
 #include	<bio.h>

--- a/src/cmd/mk/archive.c
+++ b/src/cmd/mk/archive.c
@@ -1,5 +1,9 @@
 #include	"mk.h"
+#if defined(__AIX__)
+#define ARMAG	"<bigaf>\n"
+#else
 #define	ARMAG	"!<arch>\n"
+#endif
 #define	SARMAG	(sizeof(ARMAG) - sizeof(""))
 
 #define	ARFMAG	"`\n"

--- a/src/cmd/mkfile
+++ b/src/cmd/mkfile
@@ -27,7 +27,7 @@ $PLAN9/bin/lex: $PLAN9/bin/yacc
 
 # This should not be necessary.
 $PLAN9/bin/yacc: $O.yacc
-	install -c $O.yacc $PLAN9/bin/yacc
+	$INSTALL -c $O.yacc $PLAN9/bin/yacc
 $O.yacc: yacc.$O
 	$LD -o $target $prereq
 yacc.$O: yacc.c

--- a/src/cmd/rc/io.c
+++ b/src/cmd/rc/io.c
@@ -1,5 +1,5 @@
-#include <limits.h>
 #include "rc.h"
+#include <limits.h>
 #include "exec.h"
 #include "io.h"
 #include "fns.h"

--- a/src/cmd/vbackup/mount-AIX.c
+++ b/src/cmd/vbackup/mount-AIX.c
@@ -1,0 +1,1 @@
+#include "mount-none.c"

--- a/src/cmd/vbackup/vmount0.c
+++ b/src/cmd/vbackup/vmount0.c
@@ -1,3 +1,7 @@
+#if defined(__AIX__)
+#define _ALL_SOURCE
+#endif
+
 #include <u.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/lib9/dial.c
+++ b/src/lib9/dial.c
@@ -1,3 +1,7 @@
+#if defined(__AIX__)
+#define _ALL_SOURCE
+#endif
+
 #include <u.h>
 #include <libc.h>
 

--- a/src/lib9/readcons.c
+++ b/src/lib9/readcons.c
@@ -2,7 +2,9 @@
 #define NOPLAN9DEFINES
 #include <libc.h>
 #include <termios.h>
+#if !defined(__AIX__)
 #include <sys/termios.h>
+#endif
 
 static int
 rawx(int fd, int echoing)

--- a/src/libip/AIX.c
+++ b/src/libip/AIX.c
@@ -1,0 +1,1 @@
+#include "none.c"

--- a/src/libmach/AIX.c
+++ b/src/libmach/AIX.c
@@ -1,0 +1,1 @@
+#include "nosys.c"

--- a/src/libndb/sysdnsquery.c
+++ b/src/libndb/sysdnsquery.c
@@ -1,3 +1,7 @@
+#if defined(__AIX__)
+#define _ALL_SOURCE
+#endif
+
 #include <u.h>
 #include <netinet/in.h>
 #include <arpa/nameser.h>

--- a/src/mk.AIX-power
+++ b/src/mk.AIX-power
@@ -1,0 +1,2 @@
+INSTALL=installbsd
+

--- a/src/mkmk.sh
+++ b/src/mkmk.sh
@@ -211,5 +211,9 @@ echo cd `pwd`
 9c  word.c
 9c  unix.c
 9l -o o.mk arc.o archive.o bufblock.o env.o file.o graph.o job.o lex.o main.o match.o mk.o parse.o recipe.o rc.o rule.o run.o sh.o shell.o shprint.o symtab.o var.o varsub.o word.o unix.o 
-install o.mk $PLAN9/bin/mk
+if [ `uname` = AIX ]; then
+        installbsd o.mk $PLAN9/bin/mk
+else
+        install o.mk $PLAN9/bin/mk
+fi
 cd ..


### PR DESCRIPTION
This lets most everything compile under AIX using IBM's XL/C.
However, the change to lib9/fmt using stdatomic (9505cd1) breaks it as XL/C does not support C11 atomics.