### PR TITLE
all: AIX updates

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -137,7 +137,7 @@ case "$tag" in
 		cflags="$ngflags -g"
 		cflags="$cflags -D__sun__ -D__${s}__"
 		;;
-*AIX*)	usexlc
+*AIX*)		usexlc
 		cflags="$ngflags -g -D__AIX__"
 		;;
 *)

--- a/include/u.h
+++ b/include/u.h
@@ -35,8 +35,11 @@ extern "C" {
 #	define __LONG_LONG_SUPPORTED
 #endif
 #if defined(__AIX__)
-#	define _XOPEN_SOURCE 600
-#	define _ALL_SOURCE
+#	if defined(NO_ALL_SOURCE)
+#		define _XOPEN_SOURCE 600
+#	else
+#		define _ALL_SOURCE
+#	endif
 #	undef HAS_SYS_TERMIOS
 #endif
 #if defined(__APPLE__)

--- a/src/cmd/acme/regx.c
+++ b/src/cmd/acme/regx.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <draw.h>

--- a/src/cmd/diff/diffreg.c
+++ b/src/cmd/diff/diffreg.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <bio.h>

--- a/src/cmd/rc/code.c
+++ b/src/cmd/rc/code.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "io.h"
 #include "exec.h"

--- a/src/cmd/rc/exec.c
+++ b/src/cmd/rc/exec.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "getflags.h"
 #include "exec.h"

--- a/src/cmd/rc/getflags.c
+++ b/src/cmd/rc/getflags.c
@@ -1,5 +1,6 @@
 /*% cyntax -DTEST % && cc -DTEST -go # %
  */
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "getflags.h"
 #include "fns.h"

--- a/src/cmd/rc/glob.c
+++ b/src/cmd/rc/glob.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "fns.h"

--- a/src/cmd/rc/havefork.c
+++ b/src/cmd/rc/havefork.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <signal.h>
 #if defined(PLAN9PORT) && defined(__sun__)

--- a/src/cmd/rc/here.c
+++ b/src/cmd/rc/here.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/io.c
+++ b/src/cmd/rc/io.c
@@ -1,5 +1,6 @@
-#include <limits.h>
+#define NO_ALL_SOURCE
 #include "rc.h"
+#include <limits.h>
 #include "exec.h"
 #include "io.h"
 #include "fns.h"

--- a/src/cmd/rc/lex.c
+++ b/src/cmd/rc/lex.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/parse.c
+++ b/src/cmd/rc/parse.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "io.h"
 #include "fns.h"

--- a/src/cmd/rc/pcmd.c
+++ b/src/cmd/rc/pcmd.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "io.h"
 #include "fns.h"

--- a/src/cmd/rc/pfnc.c
+++ b/src/cmd/rc/pfnc.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/plan9ish.c
+++ b/src/cmd/rc/plan9ish.c
@@ -3,6 +3,7 @@
  *	By convention, exported routines herein have names beginning with an
  *	upper case letter.
  */
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/simple.c
+++ b/src/cmd/rc/simple.c
@@ -1,6 +1,7 @@
 /*
  * Maybe `simple' is a misnomer.
  */
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "getflags.h"
 #include "exec.h"

--- a/src/cmd/rc/subr.c
+++ b/src/cmd/rc/subr.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/syn.y
+++ b/src/cmd/rc/syn.y
@@ -10,6 +10,7 @@
 %right '$' COUNT '"'
 %left SUB
 %{
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "fns.h"
 %}

--- a/src/cmd/rc/trap.c
+++ b/src/cmd/rc/trap.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "fns.h"

--- a/src/cmd/rc/tree.c
+++ b/src/cmd/rc/tree.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "io.h"

--- a/src/cmd/rc/unixcrap.c
+++ b/src/cmd/rc/unixcrap.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <sys/time.h>
 #include <sys/stat.h>

--- a/src/cmd/rc/var.c
+++ b/src/cmd/rc/var.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include "rc.h"
 #include "exec.h"
 #include "fns.h"

--- a/src/cmd/sam/sam.h
+++ b/src/cmd/sam/sam.h
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <plumb.h>

--- a/src/libdiskfs/ext2.c
+++ b/src/libdiskfs/ext2.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <thread.h>

--- a/src/libdiskfs/ffs.c
+++ b/src/libdiskfs/ffs.c
@@ -1,3 +1,4 @@
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <thread.h>

--- a/src/libdiskfs/hfs.c
+++ b/src/libdiskfs/hfs.c
@@ -5,6 +5,7 @@
 		Hfsbadblock is untested.
 */
 
+#define NO_ALL_SOURCE
 #include <u.h>
 #include <libc.h>
 #include <thread.h>


### PR DESCRIPTION
On AIX, in most cases defining _ALL_SOURCE is the right thing to do.  But occasionally it isn't.
This gets sticky because in some cases _ALL_SOURCE is the only feature test macro that causes some things to be defined that we definitely don't want, as is the case with libdiskfs, acme, etc.  In other cases, such as parts of lib9, it's the only feature test macro that defines some things we need in netinet/in.h.  I wasn't able to find a good solution that fits both use cases.  I'm open to suggestions for alternatives.