### PR TITLE
Fix devdraw and lib9 so it works again in linux and x11

### DIFF
--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -40,6 +40,26 @@ static void _xmovewindow(Xwin *w, Rectangle r);
 static int _xtoplan9kbd(XEvent *e);
 static int _xselect(XEvent *e);
 
+static void	rpc_resizeimg(Client*);
+static void	rpc_resizewindow(Client*, Rectangle);
+static void	rpc_setcursor(Client*, Cursor*, Cursor2*);
+static void	rpc_setlabel(Client*, char*);
+static void	rpc_setmouse(Client*, Point);
+static void	rpc_topwin(Client*);
+static void	rpc_bouncemouse(Client*, Mouse);
+static void	rpc_flush(Client*, Rectangle);
+
+static ClientImpl x11impl = {
+	rpc_resizeimg,
+	rpc_resizewindow,
+	rpc_setcursor,
+	rpc_setlabel,
+	rpc_setmouse,
+	rpc_topwin,
+	rpc_bouncemouse,
+	rpc_flush
+};
+
 static Xwin*
 newxwin(Client *c)
 {
@@ -51,6 +71,7 @@ newxwin(Client *c)
 	w->client = c;
 	w->next = _x.windows;
 	_x.windows = w;
+	c->impl = &x11impl;
 	c->view = w;
 	return w;
 }

--- a/src/lib9/open.c
+++ b/src/lib9/open.c
@@ -318,7 +318,7 @@ dirreadmax(int fd, Dir **dp, int max)
 				return -1;
 			break;
 		}
-		if(de->d_name[de->d_namlen] != 0)
+		if(de->d_name[_D_EXACT_NAMLEN(de)] != 0)
 			sysfatal("bad readdir");
 		if(de->d_name[0]=='.' && de->d_name[1]==0)
 			continue;


### PR DESCRIPTION
I don't know if the recent changes are related to a bigger redesign, but these changes make devdraw and lib9 to build and work on linux/x11 again.
