### PR TITLE
ed: handle Unicode beyond the BMP correctly in list mode.

### DIFF
--- a/man/man1/ed.1
+++ b/man/man1/ed.1
@@ -441,10 +441,18 @@ a backspace as
 .LR \eb ,
 backslashes as
 .LR \e\e ,
-and non-printing characters as
+and non-printing ASCII characters as
 a backslash, an
 .LR x ,
-and four hexadecimal digits.
+and two hexadecimal digits.
+non-ASCII characters in the Basic Multilingual Plane
+are printed as a backslash, a small
+.LR u ,
+and four hexadecimal digits; and characters above the
+Basic Multilingual Plane are printed as a backslash,
+a big
+.LR U ,
+and six hexadecimal digits.
 Long lines are folded,
 with the second and subsequent sub-lines indented one tab stop.
 If the last character in the line is a blank,

--- a/src/cmd/ed.c
+++ b/src/cmd/ed.c
@@ -21,6 +21,12 @@ enum
 	EOF	= -1
 };
 
+enum
+{
+	LINELEN = 70,	/* max number of glyphs in a display line */
+	BELL = 6	/* A char could require up to BELL glyphs to display */
+};
+
 void	(*oldhup)(int);
 void	(*oldquit)(int);
 int*	addr1;
@@ -40,7 +46,7 @@ int	ichanged;
 int	io;
 Biobuf	iobuf;
 int	lastc;
-char	line[70];
+char	line[LINELEN];
 Rune*	linebp;
 Rune	linebuf[LBSIZE];
 int	listf;
@@ -1543,7 +1549,7 @@ putchr(int ac)
 				*lp++ = 'n';
 			}
 		} else {
-			if(col > (72-6-2)) {
+			if(col > (LINELEN-BELL)) {
 				col = 8;
 				*lp++ = '\\';
 				*lp++ = '\n';
@@ -1558,15 +1564,30 @@ putchr(int ac)
 				if(c == '\t')
 					c = 't';
 				col++;
-			} else
-			if(c<' ' || c>='\177') {
+			} else if (c<' ' || c=='\177') {
 				*lp++ = '\\';
 				*lp++ = 'x';
-				*lp++ =  hex[c>>12];
-				*lp++ =  hex[c>>8&0xF];
-				*lp++ =  hex[c>>4&0xF];
-				c     =  hex[c&0xF];
+				*lp++ = hex[(c>>4)&0xF];
+				c     = hex[c&0xF];
+				col += 3;
+			} else if (c>'\177' && c<=0xFFFF) {
+				*lp++ = '\\';
+				*lp++ = 'u';
+				*lp++ = hex[(c>>12)&0xF];
+				*lp++ = hex[(c>>8)&0xF];
+				*lp++ = hex[(c>>4)&0xF];
+				c     = hex[c&0xF];
 				col += 5;
+			} else if (c>0xFFFF) {
+				*lp++ = '\\';
+				*lp++ = 'U';
+				*lp++ = hex[(c>>20)&0xF];
+				*lp++ = hex[(c>>16)&0xF];
+				*lp++ = hex[(c>>12)&0xF];
+				*lp++ = hex[(c>>8)&0xF];
+				*lp++ = hex[(c>>4)&0xF];
+				c     = hex[c&0xF];
+				col += 7;
 			}
 		}
 	}
@@ -1574,7 +1595,7 @@ putchr(int ac)
 	rune = c;
 	lp += runetochar(lp, &rune);
 
-	if(c == '\n' || lp >= &line[sizeof(line)-5]) {
+	if(c == '\n' || lp >= &line[LINELEN-BELL]) {
 		linp = line;
 		write(oflag? 2: 1, line, lp-line);
 		return;


### PR DESCRIPTION
In list mode, `ed` does not display Unicode codepoints beyond the Basic Multingual Plane correctly. For example, the 😀 emoji (codepoint `U01F600`) should be displayed in list mode as something like `\x01f600`. Instead, we get `\xR600`, which is gibberish.

However, fixing display mode to print every non-ASCII character as an eight-glyph string (`\xhhhhhh`) is hugely distracting, as BMP and/or ASCII codepoints predominate most texts, and list mode becomes cluttered with leading zeros.

One solution is to have `ed` display in list mode only the digits actually needed: two digits for non-printing ASCII; four digits for non-ASCII BMP codepoints, and six digits for codepoints beyond the BMP.

However, if we retain the single `\x` sigil, we create ambiguities: is `\x10f600` a single codepoint, or is it a sequence `\x10f6` followed by the two literal ASCII characters `00`? One solution to this is to make use of three distinct sigils: `\xhh` for non-printing ASCII; `\uhhhh` for non-ASCII BMP codepoints, and `\Uhhhhhh` for codepoints beyond the BMP.

This fix implements exactly this protocol, and updates the `ed(1)` manpage accordingly.