### PR TITLE
buffer overflows in libhtml/lex.c and cmd/htmlroff/roff.c

### DIFF
--- a/src/cmd/htmlroff/roff.c
+++ b/src/cmd/htmlroff/roff.c
@@ -257,7 +257,7 @@ copyarg(void)
 	int c;
 	Rune *r;
 
-	if(_readx(buf, sizeof(buf)/sizeof(*buf), ArgMode, 0) < 0)
+	if(_readx(buf, nelem(buf), ArgMode, 0) < 0)
 		return nil;
 	r = runestrstr(buf, L("\\\""));
 	if(r){
@@ -280,7 +280,7 @@ readline(int m)
 	static Rune buf[MaxLine];
 	Rune *r;
 
-	if(_readx(buf, sizeof(buf)/sizeof(*buf), m, 1) < 0)
+	if(_readx(buf, nelem(buf), m, 1) < 0)
 		return nil;
 	r = erunestrdup(buf);
 	return r;

--- a/src/cmd/htmlroff/roff.c
+++ b/src/cmd/htmlroff/roff.c
@@ -257,7 +257,7 @@ copyarg(void)
 	int c;
 	Rune *r;
 
-	if(_readx(buf, sizeof buf, ArgMode, 0) < 0)
+	if(_readx(buf, sizeof(buf)/sizeof(*buf), ArgMode, 0) < 0)
 		return nil;
 	r = runestrstr(buf, L("\\\""));
 	if(r){
@@ -280,7 +280,7 @@ readline(int m)
 	static Rune buf[MaxLine];
 	Rune *r;
 
-	if(_readx(buf, sizeof buf, m, 1) < 0)
+	if(_readx(buf, sizeof(buf)/sizeof(*buf), m, 1) < 0)
 		return nil;
 	r = erunestrdup(buf);
 	return r;

--- a/src/libhtml/lex.c
+++ b/src/libhtml/lex.c
@@ -586,7 +586,7 @@ getplaindata(TokenSource* ts, Token* a, int* pai)
 		}
 		if(c != 0){
 			buf[j++] = c;
-			if(j == sizeof(buf)-1){
+			if(j == sizeof(buf)/sizeof(*buf)-1){
 				s = buftostr(s, buf, j);
 				j = 0;
 			}

--- a/src/libhtml/lex.c
+++ b/src/libhtml/lex.c
@@ -586,7 +586,7 @@ getplaindata(TokenSource* ts, Token* a, int* pai)
 		}
 		if(c != 0){
 			buf[j++] = c;
-			if(j == sizeof(buf)/sizeof(*buf)-1){
+			if(j == nelem(buf)-1){
 				s = buftostr(s, buf, j);
 				j = 0;
 			}


### PR DESCRIPTION
_readx() uses length as its argument and not size, getplaindata() should check if j == length -1