### PR TITLE
Include libfontconfig1-dev as required package for Debian

### DIFF
--- a/man/man1/install.1
+++ b/man/man1/install.1
@@ -100,9 +100,8 @@ Values more complex than single words should be quoted
 with single quotes.
 .PP
 On most Linux systems, the X11 header packages need to be installed
-to build using X11.  On Debian. the required packages are
-libx11-dev, libxext-dev, and libxt-dev.
-On Ubuntu, it suffices to install xorg-dev.
+to build using X11. On Debian and Ubuntu the required packages are
+libx11-dev, libxext-dev, libxt-dev and libfontconfig1-dev.
 .PP
 .I INSTALL
 can safely be repeated to rebuild the system from scratch.


### PR DESCRIPTION
in the install(1) manpage, required packages for Debian are libx11-dev, libxext-dev, and libxt-dev

I think libfontconfig1-dev is also needed:

>>> cd /home/kix/src/plan9port/src/cmd/fontsrv; mk all
9c -I/usr/include -I/usr/include/freetype2 x11.c
x11.c:3:35: fatal error: fontconfig/fontconfig.h: No such file or directory
compilation terminated.
mk: 9c -I/usr/include -I/usr/include/freetype2 x11.c  : exit status=exit(1)
mk: for i in ...  : exit status=exit(1)
mk: for i in ...  : exit status=exit(1)

Debian and Ubuntu are similar, so we can change these lines:

On most Linux systems, the X11 header packages need to be installed
to build using X11.  On Debian. the required packages are
libx11-dev, libxext-dev, and libxt-dev.
On Ubuntu, it suffices to install xorg-dev.

to:

On most Linux systems, the X11 header packages need to be installed
to build using X11. On Debian and Ubuntu the required packages are
libx11-dev, libxext-dev, libxt-dev and libfontconfig1-dev.

Signed-off-by: Rodolfo García Peñas (kix) <kix@kix.es>