### PR TITLE
libdraw: fix out-of-bounds access to local buffer in event.c:startrpc()

### DIFF
--- a/src/libdraw/event.c
+++ b/src/libdraw/event.c
@@ -203,7 +203,7 @@ newebuf(Slave *s, int n)
 static Muxrpc*
 startrpc(int type)
 {
-	uchar buf[100];
+	uchar buf[512];
 	Wsysmsg w;
 
 	w.type = type;

--- a/src/libdraw/event.c
+++ b/src/libdraw/event.c
@@ -207,7 +207,8 @@ startrpc(int type)
 	Wsysmsg w;
 
 	w.type = type;
-	convW2M(&w, buf, sizeof buf);
+	if(convW2M(&w, buf, sizeof buf) == 0)
+		return nil;
 	return muxrpcstart(display->mux, buf);
 }
 


### PR DESCRIPTION
The function `startrpc()` stack allocates a local buffer of size 100:

```c
static Muxrpc*
startrpc(int type)
{
	uchar buf[100];
	      ^^^^^^^^
	Wsysmsg w;

	w.type = type;
	convW2M(&w, buf, sizeof buf);
	return muxrpcstart(display->mux, buf);
}
```

The function `convW2M()` is called passing `buf`. That function accesses
`buf` out-of-bounds:

```c
uint
convW2M(Wsysmsg *m, uchar *p, uint n)
{
  ...
  case Tcursor2:
    PUT(p+6, m->cursor.offset.x);
    PUT(p+10, m->cursor.offset.y);
    memmove(p+14, m->cursor.clr, sizeof m->cursor.clr);
    memmove(p+46, m->cursor.set, sizeof m->cursor.set);
    PUT(p+78, m->cursor2.offset.x);
    PUT(p+82, m->cursor2.offset.y);
    memmove(p+86, m->cursor2.clr, sizeof m->cursor2.clr);
    memmove(p+214, m->cursor2.set, sizeof m->cursor2.set);
    p[342] = m->arrowcursor;
    ^^^^^^
```

To fix the issue the size of local variable `buf` is increased from 100
to 512 to avoid out-of-bounds array access.