### PR TITLE
deroff: fix out-of-bounds access if runes above 0X80 are inside EQ clauses

### DIFF
--- a/src/cmd/deroff.c
+++ b/src/cmd/deroff.c
@@ -745,7 +745,7 @@ eqn(void)
 		}
 		if(c != '\n')
 			while(C1 != '\n') {
-				if(chars[c] == PUNCT)
+				if(charclass(c) == PUNCT)
 					last = c;
 				else
 				if(c != ' ')


### PR DESCRIPTION
Characters greater than 0X80 will cause a read beyond the bounds of the
array chars[].  For particular unicode characters this can cause deroff
to segfault.

A minimal example:
$ deroff
.EQ
u∈
Segmentation fault

Throughout deroff, charclass() is used instead of directly indexing
chars[] so I presume this was just missed.