### PR TITLE
touch: fix for OpenBSD.

### DIFF
--- a/src/cmd/touch.c
+++ b/src/cmd/touch.c
@@ -54,7 +54,7 @@ touch(int nocreate, char *name)
 		fprint(2, "touch: %s: cannot wstat: %r\n", name);
 		return 1;
 	}
-	if((fd = create(name, OREAD, 0666)) < 0) {
+	if((fd = create(name, OWRITE, 0666)) < 0) {
 		fprint(2, "touch: %s: cannot create: %r\n", name);
 		return 1;
 	}


### PR DESCRIPTION
This fixes https://github.com/9fans/plan9port/issues/436

This doesn't necessarily address the underlying issue: calling p9create with
mode = OREAD should probably be allowed, but currently doesn't work on
OpenBSD.