### PR TITLE
lib9: create() should use O_TRUNC only on O_RDWR or O_WRONLY

### DIFF
--- a/src/lib9/open.c
+++ b/src/lib9/open.c
@@ -95,7 +95,10 @@ p9create(char *path, int mode, ulong perm)
 			goto out;
 		fd = open(path, O_RDONLY);
 	}else{
-		umode = (mode&3)|O_CREAT|O_TRUNC;
+		if (mode == OREAD || mode == OEXEC)
+			umode = (mode&3)|O_CREAT;
+		else
+			umode = (mode&3)|O_CREAT|O_TRUNC;
 		mode &= ~(3|OTRUNC);
 		if(mode&ODIRECT){
 			umode |= O_DIRECT;


### PR DESCRIPTION
It addresses a better fix for #439 for fixing likely remaining cases:

openbsd$ grep -rn " create(" * | grep OREAD | grep -v DMDIR 
src/cmd/auth/secstore/secuser.c:22:	fd = create(f, OREAD, perm);
src/cmd/disk/mkext.c:161:	fd = create(name, OREAD, mode);
src/cmd/disk/mkfs.c:452:	fd = create(newfile, OREAD, d->mode);
src/cmd/upas/common/libsys.c:102:		fd = create(s_to_c(l->name), OREAD, DMEXCL|0666);
src/cmd/upas/common/libsys.c:823:	fd = create(file, OREAD, perm);
src/cmd/upas/pop3/pop3.c:729:	fd = create(buf, OREAD, 0666);

