### PR TITLE
Selection and Clipboard cleanup

### DIFF
--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -1576,23 +1576,12 @@ __xputsnarf(char *data)
 static int
 _xselect(XEvent *e)
 {
-	char *name;
 	XEvent r;
 	XSelectionRequestEvent *xe;
-	Atom a[4];
 
 	memset(&r, 0, sizeof r);
 	xe = (XSelectionRequestEvent*)e;
-if(0) fprint(2, "xselect target=%d requestor=%d property=%d selection=%d (sizeof atom=%d)\n",
-	xe->target, xe->requestor, xe->property, xe->selection, sizeof a[0]);
-	MODIFY_SELECTION(name, xe) {
-		name = XGetAtomName(_x.display, xe->target);
-		if(strcmp(name, "TIMESTAMP") != 0)
-		        fprint(2, "%s: cannot handle selection request for '%s' (%d)\n",
-		            argv0, name, (int)xe->target);
-		r.xselection.property = None;
-	}
-         if (name) XFree(name);
+	MODIFY_SELECTION(xe);
 	r.xselection.display = xe->display;
 	/* r.xselection.property filled above */
 	r.xselection.target = xe->target;

--- a/src/cmd/devdraw/x11-selection-mod.h
+++ b/src/cmd/devdraw/x11-selection-mod.h
@@ -1,0 +1,27 @@
+/* a few snippets for selections */
+#define MODIFY_SELECTION(name, xe) \
+	r.xselection.property = xe->property; \
+         name = 0x0; \
+	if(xe->target == _x.targets){ \
+		a[0] = _x.utf8string; \
+		a[1] = XA_STRING; \
+		a[2] = _x.text; \
+		a[3] = _x.compoundtext; \
+		XChangeProperty(_x.display, xe->requestor, xe->property, XA_ATOM, \
+			32, PropModeReplace, (uchar*)a, nelem(a)); \
+	}else if(xe->target == XA_STRING \
+	|| xe->target == _x.utf8string \
+	|| xe->target == _x.text \
+	|| xe->target == _x.compoundtext \
+	|| ((name = XGetAtomName(_x.display, xe->target)) \
+           && ((cistrcmp(name, "text/plain;charset=UTF-8") == 0) \
+              || (cistrcmp(name, "text/uri-list") == 0)))){ \
+		/* text/plain;charset=UTF-8 seems nonstandard but is used by Synergy */ \
+		/* if the target is STRING we're supposed to reply with Latin1 XXX */ \
+		xunlock(); \
+		qlock(&clip.lk); \
+		xlock(); \
+		XChangeProperty(_x.display, xe->requestor, xe->property, xe->target, \
+			8, PropModeReplace, (uchar*)clip.buf, strlen(clip.buf)); \
+		qunlock(&clip.lk); \
+	}else

--- a/src/cmd/snarfer/snarfer.c
+++ b/src/cmd/snarfer/snarfer.c
@@ -144,27 +144,12 @@ main(int argc, char **argv)
 void
 xselectionrequest(XEvent *e)
 {
-	char *name;
-	Atom a[4];
 	XEvent r;
 	XSelectionRequestEvent *xe;
-	XDisplay *xd;
-
-	xd = _x.display;
 
 	memset(&r, 0, sizeof r);
 	xe = (XSelectionRequestEvent*)e;
-if(0) fprint(2, "xselect target=%d requestor=%d property=%d selection=%d\n",
-	xe->target, xe->requestor, xe->property, xe->selection);
-         MODIFY_SELECTION(name, xe){
-		name = XGetAtomName(xd, xe->target);
-		if(strcmp(name, "TIMESTAMP") != 0)
-		        fprint(2, "%s: cannot handle selection request for '%s' (%d)\n",
-		            argv0, name, (int)xe->target);
-		r.xselection.property = None;
-                  if (name) { XFree(name); name= 0x0; }
-	}
-
+         MODIFY_SELECTION(xe);
 	r.xselection.display = xe->display;
 	/* r.xselection.property filled above */
 	r.xselection.target = xe->target;
@@ -173,8 +158,8 @@ if(0) fprint(2, "xselect target=%d requestor=%d property=%d selection=%d\n",
 	r.xselection.time = xe->time;
 	r.xselection.send_event = True;
 	r.xselection.selection = xe->selection;
-	XSendEvent(xd, xe->requestor, False, 0, &r);
-	XFlush(xd);
+	XSendEvent(_x.display, xe->requestor, False, 0, &r);
+	XFlush(_x.display);
 }
 
 char*


### PR DESCRIPTION
I found two similar pieces of code, that are responsible for some warning message on my system, due to extended use of atoms for clipboard mime types (text/plain;charset=utf-8 and text/url-list).
This change simplifies the code, by exporting the handling of extensions into a simple macro block: MODIFY_SELECTION(xe), with the XSelectionEvent*xe.
