### PR TITLE
cmd/faces,cmd/upas/nfs: make it possible to run many instances of faces

### DIFF
--- a/src/cmd/faces/faces.h
+++ b/src/cmd/faces/faces.h
@@ -46,6 +46,7 @@ extern char	*maildir;
 extern char	**maildirs;
 extern int	nmaildirs;
 extern CFsys	*mailfs;
+extern char	*srvname;
 
 Face*	nextface(void);
 void	findbit(Face*);

--- a/src/cmd/faces/main.c
+++ b/src/cmd/faces/main.c
@@ -77,6 +77,7 @@ int	ndown;
 char	date[64];
 Face	**faces;
 char	*maildir = "mbox";
+char	*srvname = "mail";
 ulong	now;
 
 Point	datep = { 8, 6 };
@@ -98,7 +99,7 @@ setdate(void)
 void
 init(void)
 {
-	mailfs = nsmount("mail", nil);
+	mailfs = nsmount(srvname, nil);
 	if(mailfs == nil)
 		sysfatal("mount mail: %r");
 	mousectl = initmouse(nil, screen);
@@ -664,7 +665,7 @@ killall(char *s)
 void
 usage(void)
 {
-	fprint(2, "usage: faces [-hi] [-m maildir] -W winsize\n");
+	fprint(2, "usage: faces [-hi] [-s srvname] [-m maildir] -W winsize\n");
 	threadexitsall("usage");
 }
 
@@ -685,6 +686,9 @@ threadmain(int argc, char *argv[])
 	case 'm':
 		addmaildir(EARGF(usage()));
 		maildir = nil;
+		break;
+	case 's':
+		srvname = EARGF(usage());
 		break;
 	case 'W':
 		winsize = EARGF(usage());

--- a/src/cmd/faces/plumb.c
+++ b/src/cmd/faces/plumb.c
@@ -211,6 +211,11 @@ nextface(void)
 			plumbfree(m);
 			continue;
 		}
+		t = value(m->attr, "srvname", srvname);
+		if(strcmp(t, srvname) != 0){
+			plumbfree(m);
+			continue;
+		}
 		data = m->data+5;
 		t = value(m->attr, "mailtype", "");
 		if(strcmp(t, "delete") == 0)

--- a/src/cmd/upas/ned/nedmail.c
+++ b/src/cmd/upas/ned/nedmail.c
@@ -189,7 +189,7 @@ CFsys *mailfs;
 void
 usage(void)
 {
-	fprint(2, "usage: %s [-nr] [-f mailfile] [-s mailfile]\n", argv0);
+	fprint(2, "usage: %s [-nr] [-S srvname] [-f mailfile] [-s mailfile]\n", argv0);
 	fprint(2, "       %s -c dir\n", argv0);
 	threadexitsall("usage");
 }

--- a/src/cmd/upas/nfs/a.h
+++ b/src/cmd/upas/nfs/a.h
@@ -36,6 +36,7 @@ char*	tcs(char*, char*);
 char*	unrfc2047(char*);
 
 extern Imap *imap;
+extern char *srvname;
 
 #undef isnumber
 #define isnumber	upas_isnumber

--- a/src/cmd/upas/nfs/box.c
+++ b/src/cmd/upas/nfs/box.c
@@ -174,8 +174,12 @@ msgplumb(Msg *m, int delete)
 	p.type = "text";
 
 	ai = 0;
-	a[ai].name = "filetype";
+	a[ai].name = "srvname";
+	a[ai].value = srvname;
+
+	a[++ai].name = "filetype";
 	a[ai].value = "mail";
+	a[ai-1].next = &a[ai];
 
 	a[++ai].name = "mailtype";
 	a[ai].value = delete?"delete":"new";

--- a/src/cmd/upas/nfs/fs.c
+++ b/src/cmd/upas/nfs/fs.c
@@ -90,6 +90,7 @@ static char Ebadctl[] = "bad control message";
 
 Channel *fsreqchan;
 Srv fs;
+char *srvname;
 Qid rootqid;
 ulong t0;
 

--- a/src/cmd/upas/nfs/main.c
+++ b/src/cmd/upas/nfs/main.c
@@ -29,7 +29,7 @@ usage(void)
 void
 threadmain(int argc, char **argv)
 {
-	char *server, *srvname, *root, *user;
+	char *server, *root, *user;
 	int mode;
 	char *mtpt;
 


### PR DESCRIPTION
Today I was running two copies of mailfs, one with `-s domain1` one with `-s domain2`, and corresponding instances of Mail, one with `-n domain1` one with `-n domain2`, and noticed I couldn't similarly have two copies of faces.
    
The first commit allows one to specify what mailfs faces should attach to via the new `-s` option. The second commit makes mailfs plumb seemail messages that contain a srvname attribute. The third commit makes faces filter out seemail messages that come from the wrong server.

I guess another approach would keeping one instance of faces that connects to many mailfs instances, based on seemail messages (now augmented with the srvname). In that case `-s` could be specified multiple times so behavior is correct with `-i`.