### PR TITLE
fossil: fix EOF detection when reading 9P message

### DIFF
--- a/src/cmd/fossil/9proc.c
+++ b/src/cmd/fossil/9proc.c
@@ -362,9 +362,8 @@ msgRead(void* v)
 	while(!eof){
 		m = msgAlloc(con);
 
-		while((n = read9pmsg(fd, m->data, con->msize)) == 0)
-			;
-		if(n < 0){
+		n = read9pmsg(fd, m->data, con->msize);
+		if(n <= 0){
 			m->t.type = Tversion;
 			m->t.fid = NOFID;
 			m->t.tag = NOTAG;


### PR DESCRIPTION
When the 9P connection is closed, reads on the connection will keep
returning 0. So, fossil ends up looping forever, trying to read a 9P
message, consuming 100% CPU. The fix interprets 0 bytes read as EOF.

Reproduce by killing the 9pserve process serving the fossil service, or
by listening on tcp and using 9p(1).