### PR TITLE
acme: do not report ‘name’ ctl messages with spaces in names as errors

### DIFF
--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -691,7 +691,7 @@ xfidctlwrite(Xfid *x, Window *w)
 				break;
 			}
 			for(i=0; i<nr; i++)
-				if(r[i] <= ' '){
+				if(r[i] < ' '){
 					err = "bad character in file name";
 					goto out;
 				}


### PR DESCRIPTION
As spaces are officially allowed in acme(1) window (and file) names since
7b1c85f, it no longer makes sense to report names with spaces as errors
in [`src/cmd/acme/xfid.c:/^xfidctlwrite`][xfidctlwrite], when parsing `name` messages
written to the window control files `acme/$winid/ctl` in 9P.

[xfidctlwrite]: https://github.com/9fans/plan9port/blob/291f7411783bf6871b253f3b15ce691eea7a257e/src/cmd/acme/xfid.c#L622
