### PR TITLE
wintext: add to moveplan9.files

### DIFF
--- a/lib/moveplan9.files
+++ b/lib/moveplan9.files
@@ -34,6 +34,7 @@ bin/upas/unspambox
 bin/venti/conf
 bin/vmount
 bin/vwhois
+bin/wintext
 bin/yesterday
 dist/debian/mkpkg
 dist/debian/mkrep


### PR DESCRIPTION
In 0bd14783426d137428ffae7cd89cfc06b88d1b11, `bin/wintext` became an rc executable. That means its shebang now needs to be rewritten by moveplan9.sh.

Without this, wintext is broken when plan9port is installed somewhere other than `/usr/local/plan9`.