### PR TITLE
Fix a few out of bounds array access reported by gcc 10.2

### DIFF
--- a/src/cmd/eqn/e.h
+++ b/src/cmd/eqn/e.h
@@ -20,7 +20,7 @@ extern int class[LAST][LAST];
 
 #undef	sprintf	/* Snow Leopard */
 
-extern	char	errbuf[200];
+extern	char	errbuf[2000];
 extern	char	*cmdname;
 #define	ERROR	sprintf(errbuf,
 #define	FATAL	), error(1, errbuf)

--- a/src/cmd/eqn/input.c
+++ b/src/cmd/eqn/input.c
@@ -255,7 +255,7 @@ void yyerror(char *s)
 	error(0, s);	/* temporary */
 }
 
-char errbuf[200];
+char errbuf[2000];
 
 void eprint(void)	/* try to print context around error */
 {

--- a/src/cmd/htmlroff/roff.c
+++ b/src/cmd/htmlroff/roff.c
@@ -257,7 +257,7 @@ copyarg(void)
 	int c;
 	Rune *r;
 
-	if(_readx(buf, sizeof buf, ArgMode, 0) < 0)
+	if(_readx(buf, MaxLine, ArgMode, 0) < 0)
 		return nil;
 	r = runestrstr(buf, L("\\\""));
 	if(r){
@@ -280,7 +280,7 @@ readline(int m)
 	static Rune buf[MaxLine];
 	Rune *r;
 
-	if(_readx(buf, sizeof buf, m, 1) < 0)
+	if(_readx(buf, MaxLine, m, 1) < 0)
 		return nil;
 	r = erunestrdup(buf);
 	return r;

--- a/src/cmd/xd.c
+++ b/src/cmd/xd.c
@@ -327,7 +327,7 @@ swizz8(void)
 		*q++ = *p++;
 	p = data;
 	q = swdata;
-	for(i=0; i<8; i++){
+	for(i=0; i<2; i++){
 		p[0] = q[7];
 		p[1] = q[6];
 		p[2] = q[5];

--- a/src/libhtml/lex.c
+++ b/src/libhtml/lex.c
@@ -586,7 +586,7 @@ getplaindata(TokenSource* ts, Token* a, int* pai)
 		}
 		if(c != 0){
 			buf[j++] = c;
-			if(j == sizeof(buf)-1){
+			if(j == BIGBUFSIZE-1){
 				s = buftostr(s, buf, j);
 				j = 0;
 			}


### PR DESCRIPTION
There are a few more warnings I don't have time to look at.  Below are the remaining warnings.

```
>>> cd /home/xjin/pkg/p9p/src/libmach; mk all               
9c -I. machpower.c
machpower.c:223:34: warning: ‘i.rd’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  223 |   if (x.op == 24 && x.rs == x.ra && x.ra == i->rd) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
machpower.c:1188:8: note: ‘i.rd’ was declared here
 1188 |  Instr i;
      |        ^
>>> cd /home/xjin/pkg/p9p/src/libplumb; mk all
9c mesg.c
mesg.c:308:12: warning: ‘attr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  308 |  m->attr = plumbunpackattr(attr);
      |            ^~~~~~~~~~~~~~~~~~~~~
/home/xjin/pkg/p9p/include/libc.h:140:14: warning: ‘ntext’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  140 | #define free p9free
      |              ^~~~~~
mesg.c:294:8: note: ‘ntext’ was declared here
  294 |  char *ntext, *attr;
      |        ^~~~~
>>> cd /home/xjin/pkg/p9p/src/cmd; mk all     
9c join.c
join.c:304:19: warning: array subscript -1 is below array bounds of ‘Rune *[101]’ {aka ‘unsigned int *[101]’} [-Warray-bounds]
  304 |     temp = ppi[F1][j1];
      |            ~~~~~~~^~~~
join.c:306:19: warning: array subscript -1 is below array bounds of ‘Rune *[101]’ {aka ‘unsigned int *[101]’} [-Warray-bounds]
  306 |     temp = ppi[F2][j2];
      |            ~~~~~~~^~~~
```