### PR TITLE
9term: do not call bouncemouse()

### DIFF
--- a/src/cmd/9term/9term.c
+++ b/src/cmd/9term/9term.c
@@ -231,8 +231,6 @@ mousethread(void *v)
 			goto Send;
 		}else if(mouse->buttons&2)
 			button2menu(w);
-		else
-			bouncemouse(mouse);
 	}
 }
 


### PR DESCRIPTION
Fixes #356.

Rio allows to hit b3 on non-focused windows to bring up its menu,
which is certainly convenient. 9term makes this happen when b3 is
clicked on its window when it's focused, too, which seems an
exception we could do without and which causes #356. (A workaround,
to make the rio menu go away when this patch is not applied, is to
hover to the 9term's scrollbar and click another button there.)