### PR TITLE
acme: add x11 mappings

### DIFF
--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -761,14 +761,17 @@ texttype(Text *t, Rune r)
 		textshow(t, q0, q0, TRUE);
 		return;
 	case Kcmd+'c':	/* %C: copy */
+	case 0x03:	/* ^C: copy */
 		typecommit(t);
 		cut(t, t, nil, TRUE, FALSE, nil, 0);
 		return;
 	case Kcmd+'z':	/* %Z: undo */
+	case 0x1a:	/* ^Z: undo */
 	 	typecommit(t);
 		undo(t, nil, nil, TRUE, 0, nil, 0);
 		return;
 	case Kcmd+'Z':	/* %-shift-Z: redo */
+	case 0x19:	/* ^Y: redo */
 	 	typecommit(t);
 		undo(t, nil, nil, FALSE, 0, nil, 0);
 		return;
@@ -797,6 +800,7 @@ texttype(Text *t, Rune r)
 	/* cut/paste must be done after the seq++/filemark */
 	switch(r){
 	case Kcmd+'x':	/* %X: cut */
+	case 0x18:	/* ^X: cut */
 		typecommit(t);
 		if(t->what == Body){
 			seq++;
@@ -807,6 +811,7 @@ texttype(Text *t, Rune r)
 		t->iq1 = t->q0;
 		return;
 	case Kcmd+'v':	/* %V: paste */
+	case 0x16:	/* ^V: paste */
 		typecommit(t);
 		if(t->what == Body){
 			seq++;


### PR DESCRIPTION
The macOS bindings are present, but the X11 ones are not. Redo is mapped
to ^Y because the shift modifier is not translated.

This patch works, but I'd prefer if we implemented a modifier system
over keys. For example, we remove `Kctl`, `Kcmd`, `Kshift` and `Kalt`
and instead make these "modifier" keys:

```c
enum {
    Mctl= 0x0100,
    Malt=   0x0200,
    Mshift= 0x0400,
    Msuper= 0x0800,
};
```

This way, the switch can be rewritten to be:

```c
case Mctl|Mshift+'z': /* shift-^Z: redo */
```

Please let me know if this is a reasonable approach to this issue and
something you'd prefer, or if this change is adequate.