### PR TITLE
acme: fix new window y max in colresize

### DIFF
--- a/src/cmd/acme/cols.c
+++ b/src/cmd/acme/cols.c
@@ -254,8 +254,8 @@ colresize(Column *c, Rectangle r)
 			r1.max.y = r.max.y;
 		else{
 			r1.max.y = r1.min.y;
-			if(new > 0 && old > 0 && Dy(w->r) > Border+font->height){
-				r1.max.y += (Dy(w->r)-Border-font->height)*new/old + Border + font->height;
+			if(new > 0 && old > 0 && Dy(w->r) > font->height){
+				r1.max.y += (Dy(w->r)-font->height)*new/old + Border + font->height;
 			}
 		}
 		r1.max.y = max(r1.max.y, r1.min.y + Border+font->height);


### PR DESCRIPTION
The rectangle w->r does not contain Border.  While recomputing the
size of each window in cols.c:/^colresize the rectangle r1 contains
the Border, which is drawn with r2.  This patch fixes the y length of
r1 by removing the incorrect subtraction of Border from Dy(w->r).

fix #491 