### PR TITLE
libthread: use setpgid instead of setpgrp

### DIFF
--- a/src/libthread/daemonize.c
+++ b/src/libthread/daemonize.c
@@ -106,7 +106,7 @@ _threadsetupdaemonize(void)
 	 * Put it in its own process group so that we don't get a SIGHUP
 	 * when the parent exits.
 	 */
-	setpgrp();
+	setpgid(0, 0);
 
 	if(pipe(p) < 0)
 		sysfatal("passer pipe: %r");


### PR DESCRIPTION
This setpgrp breaks the build on FreeBSD (and I think all BSDs). This fix is tested on FreeBSD and macOS.

Pull request #471 already exists for this, but the fix isn't right. The correct fix is noted in the comments, but I'm not sure if there's a way to edit a pull request. This is a clean one to get the change in and the build working again.