### PR TITLE
Reverts a work-around for an old Ubuntu X11 bug

### DIFF
--- a/src/cmd/devdraw/x11-draw.c
+++ b/src/cmd/devdraw/x11-draw.c
@@ -74,9 +74,7 @@ xdraw(Memdrawparam *par)
 	 * If no source alpha and an opaque mask, we can just copy
 	 * the source onto the destination.  If the channels are the
 	 * same and the source is not replicated, XCopyArea works.
-	 * This is disabled because Ubuntu Precise seems to ship with
-	 * a buggy X server that sometimes drops the XCopyArea
-	 * requests on the floor.
+	 */
 	m = Simplemask|Fullmask;
 	if((state&(m|Replsrc))==m && src->chan==dst->chan && src->X){
 		xdst = dst->X;
@@ -87,10 +85,9 @@ xdraw(Memdrawparam *par)
 
 		XCopyArea(_x.display, xsrc->pixmap, xdst->pixmap, gc,
 			sp.x, sp.y, Dx(r), Dy(r), dp.x, dp.y);
-	/*	xdirtyxdata(dst, r); * /
+	/*	xdirtyxdata(dst, r); */
 		return 1;
 	}
-	 */
 
 	/*
 	 * If no source alpha, a 1-bit mask, and a simple source,

--- a/src/cmd/devdraw/x11-draw.c
+++ b/src/cmd/devdraw/x11-draw.c
@@ -44,7 +44,7 @@ xdraw(Memdrawparam *par)
 {
 	u32int sdval;
 	uint m, state;
-	Memimage *dst, *mask;
+	Memimage *src, *dst, *mask;
 	Point dp, mp;
 	Rectangle r;
 	Xmem *xdst, *xmask;
@@ -56,6 +56,7 @@ xdraw(Memdrawparam *par)
 	dst   = par->dst;
 	mask  = par->mask;
 	r     = par->r;
+	src   = par->src;
 	state = par->state;
 
 	/*

--- a/src/cmd/devdraw/x11-draw.c
+++ b/src/cmd/devdraw/x11-draw.c
@@ -45,9 +45,9 @@ xdraw(Memdrawparam *par)
 	u32int sdval;
 	uint m, state;
 	Memimage *src, *dst, *mask;
-	Point dp, mp;
+	Point dp, mp, sp;
 	Rectangle r;
-	Xmem *xdst, *xmask;
+	Xmem *xdst, *xmask, *xsrc;
 	XGC gc;
 
 	if(par->dst->X == nil)
@@ -74,15 +74,11 @@ xdraw(Memdrawparam *par)
 	 * If no source alpha and an opaque mask, we can just copy
 	 * the source onto the destination.  If the channels are the
 	 * same and the source is not replicated, XCopyArea works.
-	 *
 	 * This is disabled because Ubuntu Precise seems to ship with
 	 * a buggy X server that sometimes drops the XCopyArea
 	 * requests on the floor.
 	m = Simplemask|Fullmask;
 	if((state&(m|Replsrc))==m && src->chan==dst->chan && src->X){
-		Xmem *xsrc;
-		Point sp;
-
 		xdst = dst->X;
 		xsrc = src->X;
 		dp = subpt(r.min,       dst->r.min);


### PR DESCRIPTION
Reverts a work-around for an old Ubuntu X11 bug. The 12.04.5 LTS (Precise Pangolin) Ubuntu 12.04 LTS reached its regular End of Life on April 28, 2017.

The downside is ~10x increase in number of network packets, which makes Acme nearly untenable on anything but 1Gbps LAN. Used to be snappy on even mediocre networks, thanks to the optimization.
