### PR TITLE
factotum: fix log read inuse bug

### DIFF
--- a/src/cmd/auth/factotum/dat.h
+++ b/src/cmd/auth/factotum/dat.h
@@ -111,6 +111,7 @@ extern char	*owner;		/* main.c */
 extern Proto	*prototab[];	/* main.c */
 extern Ring	ring;			/* key.c */
 extern char	*rpcname[];	/* rpc.c */
+extern int		*loginuse;	/* fs.c */
 
 extern char	Easproto[];	/* err.c */
 

--- a/src/cmd/auth/factotum/fs.c
+++ b/src/cmd/auth/factotum/fs.c
@@ -260,6 +260,7 @@ fskickreply(Conv *c)
 static int inuse[nelem(dirtab)];
 int *confirminuse = &inuse[0];
 int *needkeyinuse = &inuse[1];
+int *loginuse = &inuse[5];
 static void
 fsopen(Req *r)
 {

--- a/src/cmd/auth/factotum/log.c
+++ b/src/cmd/auth/factotum/log.c
@@ -107,6 +107,7 @@ void
 logflush(Req *r)
 {
 	lbflush(&logbuf, r);
+	*loginuse = 0;
 }
 
 void


### PR DESCRIPTION
When log reading exits, inuse flag should be cleared.

Signed-off-by: Tw <wei.tan@intel.com>