### PR TITLE
9term: set/unset hold mode X property

### DIFF
--- a/include/draw.h
+++ b/include/draw.h
@@ -364,6 +364,7 @@ extern Image*	namedimage(Display*, char*);
 extern int	nameimage(Image*, char*, int);
 extern Image* allocimagemix(Display*, u32int, u32int);
 extern int	drawsetlabel(char*);
+extern int	drawsetmode(int);
 extern int	scalesize(Display*, int);
 
 /*
@@ -571,6 +572,7 @@ int		_displayconnect(Display *d);
 int		_displaycursor(Display *d, struct Cursor *c, struct Cursor2 *c2);
 int		_displayinit(Display *d, char *label, char *winsize);
 int		_displaylabel(Display *d, char *label);
+int		_displaymode(Display *d, int mode);
 int		_displaymoveto(Display *d, Point p);
 int		_displaymux(Display *d);
 int		_displayrddraw(Display *d, void *v, int n);

--- a/include/drawfcall.h
+++ b/include/drawfcall.h
@@ -25,6 +25,9 @@ tag[1] Rrdkbd rune[2]
 tag[1] Trdkbd4
 tag[1] Rrdkbd4 rune[4]
 
+tag[1] Tmode hold[4]
+tag[1] Rmode
+
 tag[1] Tlabel label[s]
 tag[1] Rlabel
 
@@ -104,6 +107,8 @@ enum {
 	Rctxt,
 	Trdkbd4 = 32,
 	Rrdkbd4,
+	Tmode = 34,
+	Rmode,
 	Tmax,
 };
 
@@ -124,6 +129,7 @@ struct Wsysmsg
 	Rune rune;
 	char *winsize;
 	char *label;
+	int mode;
 	char *snarf;
 	char *error;
 	char *id;

--- a/src/cmd/9term/wind.c
+++ b/src/cmd/9term/wind.c
@@ -672,10 +672,13 @@ wkeyctl(Window *w, Rune r)
 	 * luck getting out without ESC.  Let's see who complains.
 	 */
 	if(r==0x1B || (w->holding && r==0x7F)){	/* toggle hold */
-		if(w->holding)
+		if(w->holding){
+			drawsetmode(0);
 			--w->holding;
-		else
+		}else{
 			w->holding++;
+			drawsetmode(1);
+		}
 		wrepaint(w);
 		if(r == 0x1B)
 			return;

--- a/src/cmd/devdraw/devdraw.h
+++ b/src/cmd/devdraw/devdraw.h
@@ -50,6 +50,7 @@ struct ClientImpl
 	void (*rpc_resizewindow)(Client*, Rectangle);
 	void (*rpc_setcursor)(Client*, Cursor*, Cursor2*);
 	void (*rpc_setlabel)(Client*, char*);
+	void (*rpc_setmode)(Client*, int mode);
 	void (*rpc_setmouse)(Client*, Point);
 	void (*rpc_topwin)(Client*);
 	void (*rpc_bouncemouse)(Client*, Mouse);

--- a/src/cmd/devdraw/srv.c
+++ b/src/cmd/devdraw/srv.c
@@ -282,6 +282,11 @@ runmsg(Client *c, Wsysmsg *m)
 		replymsg(c, m);
 		break;
 
+	case Tmode:
+		c->impl->rpc_setmode(c, m->mode);
+		replymsg(c, m);
+		break;
+
 	case Trdsnarf:
 		m->snarf = rpc_getsnarf();
 		replymsg(c, m);

--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -44,6 +44,7 @@ static void	rpc_resizeimg(Client*);
 static void	rpc_resizewindow(Client*, Rectangle);
 static void	rpc_setcursor(Client*, Cursor*, Cursor2*);
 static void	rpc_setlabel(Client*, char*);
+static void	rpc_setmode(Client*, int hold);
 static void	rpc_setmouse(Client*, Point);
 static void	rpc_topwin(Client*);
 static void	rpc_bouncemouse(Client*, Mouse);
@@ -54,6 +55,7 @@ static ClientImpl x11impl = {
 	rpc_resizewindow,
 	rpc_setcursor,
 	rpc_setlabel,
+	rpc_setmode,
 	rpc_setmouse,
 	rpc_topwin,
 	rpc_bouncemouse,
@@ -774,6 +776,18 @@ rpc_setlabel(Client *client, char *label)
 		nil,		/* XA_WM_HINTS */
 		nil	/* XA_WM_CLASSHINTS */
 	);
+	XFlush(_x.display);
+	xunlock();
+}
+
+void
+rpc_setmode(Client *client, int mode)
+{
+	Xwin *w = (Xwin*)client->view;
+	int value = mode>0 ? 1 : 0;
+	Atom property = XInternAtom(_x.display, "_9WM_HOLD_MODE", False);
+	xlock();
+	XChangeProperty(_x.display, w->drawable, property, XA_INTEGER, 32, PropModeReplace, (unsigned char*)&value, 1);
 	XFlush(_x.display);
 	xunlock();
 }

--- a/src/libdraw/drawclient.c
+++ b/src/libdraw/drawclient.c
@@ -397,6 +397,16 @@ _displaylabel(Display *d, char *label)
 	return displayrpc(d, &tx, &rx, nil);
 }
 
+int
+_displaymode(Display *d, int mode)
+{
+	Wsysmsg tx, rx;
+
+	tx.type = Tmode;
+	tx.mode = mode;
+	return displayrpc(d, &tx, &rx, nil);
+}
+
 char*
 _displayrdsnarf(Display *d)
 {

--- a/src/libdraw/drawfcall.c
+++ b/src/libdraw/drawfcall.c
@@ -52,6 +52,7 @@ sizeW2M(Wsysmsg *m)
 	case Trdkbd:
 	case Trdkbd4:
 	case Rlabel:
+	case Rmode:
 	case Rctxt:
 	case Rinit:
 	case Trdsnarf:
@@ -78,6 +79,8 @@ sizeW2M(Wsysmsg *m)
 		return 4+1+1+4;
 	case Tlabel:
 		return 4+1+1+_stringsize(m->label);
+	case Tmode:
+		return 4+1+1+4;
 	case Tctxt:
 		return 4+1+1
 			+_stringsize(m->id);
@@ -122,6 +125,7 @@ convW2M(Wsysmsg *m, uchar *p, uint n)
 	case Trdkbd:
 	case Trdkbd4:
 	case Rlabel:
+	case Rmode:
 	case Rctxt:
 	case Rinit:
 	case Trdsnarf:
@@ -175,6 +179,9 @@ convW2M(Wsysmsg *m, uchar *p, uint n)
 		break;
 	case Tlabel:
 		PUTSTRING(p+6, m->label);
+		break;
+	case Tmode:
+		PUT(p+6, m->mode);
 		break;
 	case Tctxt:
 		PUTSTRING(p+6, m->id);
@@ -230,6 +237,7 @@ convM2W(uchar *p, uint n, Wsysmsg *m)
 	case Trdkbd:
 	case Trdkbd4:
 	case Rlabel:
+	case Rmode:
 	case Rctxt:
 	case Rinit:
 	case Trdsnarf:
@@ -283,6 +291,9 @@ convM2W(uchar *p, uint n, Wsysmsg *m)
 		break;
 	case Tlabel:
 		GETSTRING(p+6, &m->label);
+		break;
+	case Tmode:
+		GET(p+6, m->mode);
 		break;
 	case Tctxt:
 		GETSTRING(p+6, &m->id);
@@ -379,6 +390,10 @@ drawfcallfmt(Fmt *fmt)
 		return fmtprint(fmt, "Tlabel label='%s'", m->label);
 	case Rlabel:
 		return fmtprint(fmt, "Rlabel");
+	case Tmode:
+		return fmtprint(fmt, "Tmode mode=%d", m->mode);
+	case Rmode:
+		return fmtprint(fmt, "Rmode");
 	case Tctxt:
 		return fmtprint(fmt, "Tctxt id='%s'", m->id);
 	case Rctxt:

--- a/src/libdraw/wsys.c
+++ b/src/libdraw/wsys.c
@@ -11,6 +11,12 @@ drawtopwindow(void)
 }
 
 int
+drawsetmode(int mode)
+{
+	return _displaymode(display, mode);
+}
+
+int
 drawsetlabel(char *label)
 {
 	return _displaylabel(display, label);


### PR DESCRIPTION
Rio sets the blue border based on _9WM_HOLD_MODE.
Since 9term is not an X application, it can't call XChangeProperty directly to set that property.
There isn't an RPC in devdraw that could readily be used to implement a message from 9term to X (via devdraw) to set _9WM_HOLD_MODE, so a new one was added.

---

It seems too big a change for such a small feature but couldn't think of anything else.
I'm aware a stub is needed for Apple systems if this gets merged, but I don't have such a system to test the change on.
