### PR TITLE
lib9p: Fix compile error

### DIFF
--- a/src/lib9p/mkfile
+++ b/src/lib9p/mkfile
@@ -2,7 +2,6 @@
 
 LIB=lib9p.a
 OFILES=\
-	_post.$O\
 	dirread.$O\
 	fid.$O\
 	file.$O\


### PR DESCRIPTION
commit 385a6d5877258cee0cac6151e6359c9206006b01 removed src/lib9p/_post.c
from the code base, but overlooked removing a reference to the
_post.o object file from the src/lib9p/mkfile.

This results in lib9p failing to compile:

* Running on Darwin...
* Compiler version:
	Apple clang version 12.0.5 (clang-1205.0.22.11)
* Building mk...
* Building everything (be patient)...
>>> mk: don't know how to make '/Users/sasha/plan9port_fork/lib/lib9p.a(_post.o)' in /Users/sasha/plan9port_fork/src/lib9p
mk: for i in ...  : exit status=exit(1)

Remove _post.o from the list of dependent object files from
src/lib9p/mkfile to have lib9p compile.

Fixes: 385a6d587725 ("lib9p: Remove postmountsrv (#505)")