### PR TITLE
mk: provide a mechanism to default to `rc`

### DIFF
--- a/src/cmd/mk/shell.c
+++ b/src/cmd/mk/shell.c
@@ -41,6 +41,8 @@ setshell(Word *w)
 void
 initshell(void)
 {
+	if(getenv("FORCERCFORMK") != nil)
+		shelldefault = &rcshell;
 	shellcmd = stow(shelldefault->name);
 	shellt = shelldefault;
 	setvar("MKSHELL", shellcmd);


### PR DESCRIPTION
For cross-compiling plan9 from Unix, provide a way
to force `mk` to use `rc` instead of `sh` without
setting `MKSHELL` in individual `mkfile`s.

If the environment variable `FORCERCFORMK` is set,
`mk` will default to using `rc`, not `sh`.

Signed-off-by: Dan Cross <cross@gajendra.net>