### PR TITLE
src/cmd/acme: provide info on presense or absence of undo history

### DIFF
--- a/man/man4/acme.4
+++ b/man/man4/acme.4
@@ -184,9 +184,10 @@ is always appended; the file offset is ignored.
 .B ctl
 may be read to recover the five numbers as held in the
 .B index
-file, described above, plus three more fields: the width of the
-window in pixels, the name of the font used in the window,
-and the width of a tab character in pixels.
+file, described above, plus five more fields: the width of the
+window in pixels; the name of the font used in the window;
+the width of a tab character in pixels; a 1 if there is undo history, 0 otherwise;
+a 1 if there is redo history, 0 otherwise.
 Text messages may be written to
 .B ctl
 to affect the window.

--- a/src/cmd/acme/fns.h
+++ b/src/cmd/acme/fns.h
@@ -25,6 +25,8 @@ void	savemouse(Window*);
 int	restoremouse(Window*);
 void	clearmouse(void);
 void	allwindows(void(*)(Window*, void*), void*);
+uint seqof(Window*, int);
+
 uint loadfile(int, uint, int*, int(*)(void*, uint, Rune*, int), void*, DigestState*);
 void	movetodel(Window*);
 

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -689,8 +689,8 @@ winctlprint(Window *w, char *buf, int fonts)
 	sprint(buf, "%11d %11d %11d %11d %11d ", w->id, w->tag.file->b.nc,
 		w->body.file->b.nc, w->isdir, w->dirty);
 	if(fonts)
-		return smprint("%s%11d %q %11d ", buf, Dx(w->body.fr.r),
-			w->body.reffont->f->name, w->body.fr.maxtab);
+		return smprint("%s%11d %q %11d %11d %11d ", buf, Dx(w->body.fr.r),
+			w->body.reffont->f->name, w->body.fr.maxtab, seqof(w, 1) != 0, seqof(w, 0) != 0);
 	return buf;
 }
 


### PR DESCRIPTION
It's sometimes useful to know whether there's been editing activity
in a window. This PR adds that information to the ctl file.

Change-Id: I21a342ac636dd5c7701b3ed560e3526867329c2c