### PR TITLE
Don't hardcode /usr/local/plan9 in C source code

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,7 +16,7 @@ x-c)
 	;;
 x-r)
 	shift
-	PLAN9_TARGET=$1 export PLAN9_TARGET
+	PLAN9_TARGET=$1
 	;;
 *)
 	echo 'usage: INSTALL [-b | -c] [-r path]' 1>&2
@@ -32,6 +32,9 @@ rm -f config
 
 PLAN9=`pwd` export PLAN9
 PATH=/bin:/usr/bin:$PLAN9/bin:$PATH export PATH
+[ -z "$PLAN9_TARGET" ] && PLAN9_TARGET="$PLAN9"
+export PLAN9_TARGET
+
 case `uname` in
 SunOS)
 	awk=nawk

--- a/lib/moveplan9.sh
+++ b/lib/moveplan9.sh
@@ -12,7 +12,6 @@ case $# in
 	exit 1
 esac
 
-[ -z "$PLAN9_TARGET" ] && PLAN9_TARGET="$PLAN9"
 new=`cleanname $PLAN9_TARGET`
 
 if [ X"$new" = X"" ]

--- a/src/cmd/sam/sam.c
+++ b/src/cmd/sam/sam.c
@@ -152,9 +152,7 @@ rescue(void)
 			free(c);
 		}else
 			sprint(buf, "nameless.%d", nblank++);
-		root = getenv("PLAN9");
-		if(root == nil)
-			root = "/usr/local/plan9";
+		root = get9root();
 		fprint(io, "#!/bin/sh\n%s/bin/samsave '%s' $* <<'---%s'\n", root, buf, buf);
 		addr.r.p1 = 0, addr.r.p2 = f->b.nc;
 		writeio(f);

--- a/src/cmd/upas/nfs/imap.c
+++ b/src/cmd/upas/nfs/imap.c
@@ -825,7 +825,8 @@ imapdial(char *server, int mode)
 		fd[0] = dup(p[0], -1);
 		fd[1] = dup(p[0], -1);
 		fd[2] = dup(2, -1);
-		if(threadspawnl(fd, "/usr/local/plan9/bin/rc", "rc", "-c", server, nil) < 0){
+		/* could do better - use get9root for rc(1) path */
+		if(threadspawnl(fd, PLAN9_TARGET "/bin/rc", "rc", "-c", server, nil) < 0){
 			close(p[0]);
 			close(p[1]);
 			close(fd[0]);

--- a/src/cmd/upas/nfs/mkfile
+++ b/src/cmd/upas/nfs/mkfile
@@ -16,3 +16,5 @@ HFILES=a.h box.h imap.h sx.h
 
 <$PLAN9/src/mkone
 
+imap.$O: imap.c
+	$CC $CFLAGS -DPLAN9_TARGET=\"$PLAN9_TARGET\" imap.c

--- a/src/lib9/get9root.c
+++ b/src/lib9/get9root.c
@@ -11,7 +11,6 @@ get9root(void)
 
 	if((s = getenv("PLAN9")) != 0)
 		return s;
-	/* could do better - search $PATH */
-	s = "/usr/local/plan9";
+	s = PLAN9_TARGET;
 	return s;
 }

--- a/src/lib9/mkfile
+++ b/src/lib9/mkfile
@@ -175,6 +175,9 @@ HFILES=\
 %.$O: utf/%.c
 	$CC $CFLAGS utf/$stem.c
 
+get9root.$O: get9root.c
+	$CC $CFLAGS -DPLAN9_TARGET=\"$PLAN9_TARGET\" get9root.c
+
 XLIB=$PLAN9/lib/$LIB
 
 testfmt: testfmt.$O $XLIB

--- a/src/mkmk.sh
+++ b/src/mkmk.sh
@@ -36,7 +36,7 @@ echo cd `pwd`
 9c  exitcode.c
 9c  fcallfmt.c
 9c  frand.c
-9c  get9root.c
+9c  -DPLAN9_TARGET=\"$PLAN9_TARGET\" get9root.c
 9c  getcallerpc.c
 9c  getenv.c
 9c  getfields.c


### PR DESCRIPTION
I maintain a plan9port package for [Alpine Linux](https://alpinelinux.org). For this package, plan9port is installed to `/usr/lib/plan9` not `/usr/local/plan9` in order to comply with our packaging policy. Doing so is supported by plan9port via the `PLAN9_TARGET` environment variable and the `./INSTALL` -r flag. The installation script replaces hardcoded references to `/usr/local/plan9` with `PLAN9_TARGET` in various files via the `./lib/moveplan9.sh` script.

A few days ago I was [made aware](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/26969) that moveplan9.sh does not replace hardcoded references to `/usr/local/plan9` in C source code files since it is invoked after the code has been compiled. The following files have been identified to contain such hardcoded paths:

1. `src/lib9/get9root.c`
2. `src/cmd/sam/sam.c`
3. `src/cmd/upas/nfs/imap.c`

As such, the affected code in these files does not work correctly if plan9port is installed to `/usr/lib/plan9`. For example, get9root does not work if `$PLAN9` is not set (e.g. in a rc(1) login shell). This pull request fixes get9root by falling back to the configured `PLAN9_TARGET` via a CPP define instead of hardcoding `/usr/local/plan9` in `get9root.c`. The remaining two files have been fixed by either using get9root (`sam.c`) or using the `PLAN9_TARGET` CPP define as well (`imap.c`).

Would be nice to get this merged in order to ease packaging plan9port for Linux distributions.