### PR TITLE
libdraw: fix _fontpipe's error reading

### DIFF
--- a/src/libdraw/openfont.c
+++ b/src/libdraw/openfont.c
@@ -306,6 +306,7 @@ _fontpipe(char *name)
 		}
 		if(c == '\001')
 			break;
+		buf[nbuf] = c;
 	}
 	return p[0];
 }


### PR DESCRIPTION
`_fontpipe` executes `fontsrv -pp` for a given font name. If the font is found (the output starts with \001), the fd of `fontsrv`'s stdout(+stderr) is returned. On the other side, if the font does not exist, a buffer is filled with the returned error and `werrstr` is called passing this buffer.

However, `_fontpipe` is not writing the read bytes into the buffer. This PR fixes that.

You can reproduce the bug executing:

```
% acme -f/mnt/font/invalidfont
```

You should see:

**Before the fix**

```
% acme -f/mnt/font/invalidfont
imageinit: can't open font /mnt/font/invalidfont: **UNINITIALIZED_MEM**
acme: can't open display: **UNINITIALIZED_MEM**
```

**After the fix**

```
% acme -f/mnt/font/invalidfont
imageinit: can't open font /mnt/font/invalidfont: invalidfont: file not found
acme: can't open display: invalidfont: file not found
```