### PR TITLE
9c: fix silence two gcc warnings

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -18,6 +18,8 @@ usegcc()
 		-Wno-stringop-truncation \
 		-Wno-stringop-overflow \
 		-Wno-format-truncation \
+		-Wno-sizeof-array-div \
+		-Wno-array-parameter \
 		-fno-omit-frame-pointer \
 		-fsigned-char \
 		-fcommon \


### PR DESCRIPTION
```console
$ gcc --version
gcc (GCC) 11.1.0
```

This PR stops two warnings like as:

```
u.h:65:42: warning: expression does not compute the number of elements in this array; element type is ‘struct __jmp_buf_tag’, not ‘long int’ [-Wsizeof-array-div]
   65 | typedef long p9jmp_buf[sizeof(sigjmp_buf)/sizeof(long)];

pipe.c:12:12: warning: argument 1 of type ‘int[2]’ with mismatched bound [-Warray-parameter=]
   12 | p9pipe(int fd[2])
```
