### PR TITLE
acme: Don't move the mouse if button depressed

### DIFF
--- a/src/cmd/acme/cols.c
+++ b/src/cmd/acme/cols.c
@@ -149,7 +149,10 @@ coladd(Column *c, Window *w, Window *clone, int y)
 
 	savemouse(w);
 	/* near the button, but in the body */
-	moveto(mousectl, addpt(w->tag.scrollr.max, Pt(3, 3)));
+	/* don't move the mouse to the new window if a mouse button is depressed */
+	if(!mousectl->m.buttons)
+		moveto(mousectl, addpt(w->tag.scrollr.max, Pt(3, 3)));
+
 	barttext = &w->body;
 	return w;
 }


### PR DESCRIPTION
Don't move the mouse to a newly-created +Errors window if a mouse selection is in progress.
Fixes #19