### PR TITLE
acme/wind.c: redraw window body with bg color if too small for a single line

### DIFF
--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -235,7 +235,7 @@ winresize(Window *w, Rectangle r, int safe, int keepextra)
 			r1.min.y = min(y, r.max.y);
 			r1.max.y = r.max.y;
 		}else{
-		  draw(screen, r1, textcols[BACK], nil, ZP);
+			draw(screen, r1, textcols[BACK], nil, ZP);
 			r1.min.y = y;
 			r1.max.y = y;
 		}

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -235,6 +235,7 @@ winresize(Window *w, Rectangle r, int safe, int keepextra)
 			r1.min.y = min(y, r.max.y);
 			r1.max.y = r.max.y;
 		}else{
+		  draw(screen, r1, textcols[BACK], nil, ZP);
 			r1.min.y = y;
 			r1.max.y = y;
 		}


### PR DESCRIPTION
closes #10 

Title is self explanitory, fixes the age-old bug.