### PR TITLE
acme: accept paths with spaces in the 'name' ctl message

### DIFF
--- a/src/cmd/acme/xfid.c
+++ b/src/cmd/acme/xfid.c
@@ -691,7 +691,7 @@ xfidctlwrite(Xfid *x, Window *w)
 				break;
 			}
 			for(i=0; i<nr; i++)
-				if(r[i] <= ' '){
+				if(r[i] < ' '){
 					err = "bad character in file name";
 					goto out;
 				}


### PR DESCRIPTION
As it is allowed to use spaces in file names set interactively through
the tag since 7b1c85f, do not reject names with spaces in the 'name'
ctl message either.

Fixes #559.