### PR TITLE
plumber: allow up to libregexp's NSUBEXP subexpression match variables

### DIFF
--- a/src/cmd/plumb/match.c
+++ b/src/cmd/plumb/match.c
@@ -38,11 +38,11 @@ verbis(int obj, Plumbmsg *m, Rule *r)
 }
 
 static void
-setvar(Resub rs[10], char *match[10])
+setvar(Resub rs[NMATCHSUBEXP], char *match[NMATCHSUBEXP])
 {
 	int i, n;
 
-	for(i=0; i<10; i++){
+	for(i=0; i<NMATCHSUBEXP; i++){
 		free(match[i]);
 		match[i] = nil;
 		if(rs[i].s.sp != nil){
@@ -55,7 +55,7 @@ setvar(Resub rs[10], char *match[10])
 }
 
 int
-clickmatch(Reprog *re, char *text, Resub rs[10], int click)
+clickmatch(Reprog *re, char *text, Resub rs[NMATCHSUBEXP], int click)
 {
 	char *clickp;
 	int i, w;
@@ -66,8 +66,8 @@ clickmatch(Reprog *re, char *text, Resub rs[10], int click)
 		w = chartorune(&r, text+i);
 	clickp = text+i;
 	for(i=0; i<=click; i++){
-		memset(rs, 0, 10*sizeof(Resub));
-		if(regexec(re, text+i, rs, 10))
+		memset(rs, 0, NMATCHSUBEXP*sizeof(Resub));
+		if(regexec(re, text+i, rs, NMATCHSUBEXP))
 			if(rs[0].s.sp<=clickp && clickp<=rs[0].e.ep)
 				return 1;
 	}
@@ -77,7 +77,7 @@ clickmatch(Reprog *re, char *text, Resub rs[10], int click)
 int
 verbmatches(int obj, Plumbmsg *m, Rule *r, Exec *e)
 {
-	Resub rs[10];
+	Resub rs[NMATCHSUBEXP];
 	char *clickval, *alltext;
 	int p0, p1, ntext;
 
@@ -122,7 +122,8 @@ verbmatches(int obj, Plumbmsg *m, Rule *r, Exec *e)
 		/* must match full text */
 		if(ntext < 0)
 			ntext = strlen(alltext);
-		if(!regexec(r->regex, alltext, rs, 10) || rs[0].s.sp!=alltext || rs[0].e.ep!=alltext+ntext)
+		if(!regexec(r->regex, alltext, rs, NMATCHSUBEXP)
+		|| rs[0].s.sp!=alltext || rs[0].e.ep!=alltext+ntext)
 			break;
 		setvar(rs, e->match);
 		return 1;
@@ -300,7 +301,7 @@ freeexec(Exec *exec)
 		return;
 	free(exec->dir);
 	free(exec->file);
-	for(i=0; i<10; i++)
+	for(i=0; i<NMATCHSUBEXP; i++)
 		free(exec->match[i]);
 	free(exec);
 }

--- a/src/cmd/plumb/plumber.h
+++ b/src/cmd/plumb/plumber.h
@@ -52,10 +52,15 @@ struct Ruleset
 	char	*port;
 };
 
+enum
+{
+	NMATCHSUBEXP = 10
+};
+
 struct Exec
 {
 	Plumbmsg	*msg;
-	char			*match[10];
+	char			*match[NMATCHSUBEXP];
 	int			p0;		/* begin and end of match */
 	int			p1;
 	int			clearclick;	/* click was expanded; remove attribute */

--- a/src/cmd/plumb/plumber.h
+++ b/src/cmd/plumb/plumber.h
@@ -54,7 +54,7 @@ struct Ruleset
 
 enum
 {
-	NMATCHSUBEXP = 10
+	NMATCHSUBEXP = 32	/* bounded by ../../libregexp/regcomp.h:/NSUBEXP */
 };
 
 struct Exec

--- a/src/cmd/plumb/rules.c
+++ b/src/cmd/plumb/rules.c
@@ -254,15 +254,36 @@ filename(Exec *e, char *name)
 	return cleanname(buf);
 }
 
+static char*
+subexpmatch(Exec *e, char *s, int *numlen)
+{
+	int n, d, ok;
+	char *t;
+
+	n = 0;
+	ok = 1;
+	for(t = s; '0'<=*t && *t<='9'; t++)
+		if(ok){
+			d = *t-'0';
+			if(d<NMATCHSUBEXP && n<=(NMATCHSUBEXP-1-d)/10)
+				n = 10*n+d;
+			else
+				ok = 0;
+		}
+	*numlen = t-s;
+	if(t==s || !ok)
+		return nil;
+	return e->match[n];
+}
+
 char*
 dollar(Exec *e, char *s, int *namelen)
 {
 	int n;
 	static char *abuf;
 
-	*namelen = 1;
 	if(e!=nil && '0'<=s[0] && s[0]<='9')
-		return nonnil(e->match[s[0]-'0']);
+		return nonnil(subexpmatch(e, s, namelen));
 
 	n = scanvarname(s)-s;
 	*namelen = n;

--- a/src/cmd/plumb/rules.c
+++ b/src/cmd/plumb/rules.c
@@ -254,36 +254,21 @@ filename(Exec *e, char *name)
 	return cleanname(buf);
 }
 
-static char*
-subexpmatch(Exec *e, char *s, int *numlen)
-{
-	int n, d, ok;
-	char *t;
-
-	n = 0;
-	ok = 1;
-	for(t = s; '0'<=*t && *t<='9'; t++)
-		if(ok){
-			d = *t-'0';
-			if(d<NMATCHSUBEXP && n<=(NMATCHSUBEXP-1-d)/10)
-				n = 10*n+d;
-			else
-				ok = 0;
-		}
-	*numlen = t-s;
-	if(t==s || !ok)
-		return nil;
-	return e->match[n];
-}
-
 char*
 dollar(Exec *e, char *s, int *namelen)
 {
 	int n;
+	ulong m;
+	char *t;
 	static char *abuf;
 
-	if(e!=nil && '0'<=s[0] && s[0]<='9')
-		return nonnil(subexpmatch(e, s, namelen));
+	if(e!=nil && '0'<=s[0] && s[0]<='9'){
+		m = strtoul(s, &t, 10);
+		*namelen = t-s;
+		if(t==s || m>=NMATCHSUBEXP)
+			return "";
+		return nonnil(e->match[m]);
+	}
 
 	n = scanvarname(s)-s;
 	*namelen = n;


### PR DESCRIPTION
Motivated by #565.

Unlike, e.g., backslash references in replacement strings of sam’s
substitution command, where multi-digit subexpression references
would be ambigiuos, this change does not create any ambiguity that
cannot be easily avoided thanks to the single-quote literal syntax.

Granted, it is backward incompatible, but I doubt anyone wrote
something like `…$7123…` instead of `…$7'123'…`—for an eye used
to rc variable substitution syntax (which plumbing rules deliberately
resemble), the former is too uncomfortable looking, even if one knows
that in plumbing rules it works slightly differently than in rc.

In `subexpmatch()`, we consume all the digits following the dollar
sign even if the resulting number would exceed `NMATCHSUBEXP`
(or even overflow) to avoid any potential ambiguity and bring it in
line with rc behavior for such syntax.
