### PR TITLE
troff: support `\~` as an alias for `\ `

### DIFF
--- a/src/cmd/troff/n1.c
+++ b/src/cmd/troff/n1.c
@@ -512,6 +512,8 @@ g0:
 	case '\n':	/* concealed newline */
 		numtabp[CD].val++;
 		goto g0;
+	case '~':	/* Heirloom/groff/neatroff: unbreakable space */
+		; /* fall through */
 	case ' ':	/* unpaddable space */
 		i = UNPAD;
 		goto gx;


### PR DESCRIPTION
In groff, Heirloom Doctools troff, and neatroff, the `\~` escape
sequence produces an adjustable (paddable) but unbreakable space.
mandoc, which does not perform adjustment or render to typesetters,
supports the escape sequence as a synonym for `\ `, the same as `\0`.

This extension is of long pedigree: groff has supported it for at least
30 years, Heirloom for 17, mandoc for 13, and neatroff for 6.

Do the same as mandoc to prevent mis-rendering of documents using this
escape sequence.  Heirloom Doctools troff, a descendant of Documenter's
Workbench troff, would be a good place to look for a compatible
implementation of the adjustable semantics for this sequence.