### PR TITLE
Regenerate lookman index on install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -183,6 +183,9 @@ if $doinstall; then
 		echo "* NOT renaming hard-coded /usr/local/plan9 paths."
 		echo "* NOT building web manual."
 	else
+		cd $PLAN9/man
+		mk indices
+		mk lookman.index
 		echo "* Renaming hard-coded /usr/local/plan9 paths..."
 		cd $PLAN9
 		sh lib/moveplan9.sh

--- a/man/mkfile
+++ b/man/mkfile
@@ -7,5 +7,5 @@ indices:V:
 	done
 
 lookman.index:V:
-	./mkindex
+	9 rc ./mkindex
 

--- a/man/mkindex
+++ b/man/mkindex
@@ -4,11 +4,11 @@
 
 # creates the index used by lookman
 >lookman.index
-for(i in $PLAN9/man/man[0-9]*/[a-z0-9:]*.[0-9]*){
+for(i in man[0-9]*/[a-z0-9:]*.[0-9]*){
 	deroff -w_ < $i |
 	tr 'A-Z' 'a-z' |
 	sort -u |
 	comm -23 - junkwords |
-	sed 's@$@	'$i'@' >>lookman.index		# stick file name on end of line
+	sed 's@$@	'$PLAN9_TARGET/man/$i'@' >>lookman.index		# stick file name on end of line
 }
 sort -o lookman.index lookman.index


### PR DESCRIPTION
The indices in the repo have not been updated in 17 years.

I decided against pushing the updated indices themselves as the changeset is quite large.
Maybe they should just be removed and only generated on install?

```
   man/lookman.index | 10087 +++++++++++++++++++++++++++++++++++++++++++++++++++--
   man/man1/INDEX    |    11 +-
   man/man3/INDEX    |     2 +-
   3 files changed, 9804 insertions(+), 296 deletions(-)
```
This may not be the best way to do it, but it works fine for packaging in a distro.

