### PR TITLE
9l: without arguments, exit instead of failing to link nothing

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ "$1" = "" ] && exit 1
+
 test -f $PLAN9/config && . $PLAN9/config
 libsl=""
 frameworks=""


### PR DESCRIPTION
Found in Arch Linux but never reported upstream:
https://bugs.archlinux.org/task/55640

```
% 9l
/bin/ld: /usr/lib/plan9/lib/lib9.a(main.o): in function `main':
(.text.startup+0x5): undefined reference to `p9main'
collect2: error: ld returned 1 exit status
% 
```