### PR TITLE
Modernise terminology

### DIFF
--- a/man/man7/font.7
+++ b/man/man7/font.7
@@ -98,7 +98,7 @@ or
 .BR unicode .
 .B Euro
 includes most European languages, punctuation marks, the International Phonetic
-Alphabet, etc., but no Oriental languages.
+Alphabet, etc., but no Asian languages.
 .B Unicode
 includes every character for which appropriate-sized images exist on the system.
 .PP
@@ -128,7 +128,7 @@ If the font name has the form
 .BR \fIscale\fP*\fIfontname\fP ,
 where
 .I scale
-is a small decimal integer, the 
+is a small decimal integer, the
 .I fontname
 is loaded and then scaled by pixel repetition.
 .PP


### PR DESCRIPTION
The word 'Oriental' is considered very outdated now.