### PR TITLE
add macedit to moveplan9.files

### DIFF
--- a/lib/moveplan9.files
+++ b/lib/moveplan9.files
@@ -9,6 +9,7 @@ bin/doctype
 bin/fossil/conf
 bin/ipso
 bin/lookman
+bin/macedit
 bin/man
 bin/mount
 bin/netfileget


### PR DESCRIPTION
Seemingly the last use of a hardcoded /usr/local/plan9 path.