### PR TITLE
web: fix plumbing with Firefox

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -27,7 +27,7 @@ plumbunix()
 		$BROWSER -remote 'openURL('"$@"',new-window)'
 		;;
 	*firefox*)
-		$BROWSER -remote 'openURL('"$@"',new-tab)' ||
+		$BROWSER --new-tab "$@" ||
 		$BROWSER "$@"
 		;;
 	*mozilla*)


### PR DESCRIPTION
Default builds of Firefox remove the previous X remote interface,
now causing the use of -remote to silently exit and do nothing.

https://hg.mozilla.org/mozilla-central/rev/ef22d8cbf4ef