### PR TITLE
src/cmd: print all usage messages to stderr

### DIFF
--- a/src/cmd/cmp.c
+++ b/src/cmd/cmp.c
@@ -107,6 +107,6 @@ main(int argc, char *argv[])
 static void
 usage(void)
 {
-	print("Usage: cmp [-lsL] file1 file2 [offset1 [offset2] ]\n");
+	fprint(2, "Usage: cmp [-lsL] file1 file2 [offset1 [offset2] ]\n");
 	exits("usage");
 }

--- a/src/cmd/getflags.c
+++ b/src/cmd/getflags.c
@@ -4,7 +4,7 @@
 void
 usage(void)
 {
-	print("status=usage\n");
+	fprint(2, "status=usage\n");
 	exits(0);
 }
 


### PR DESCRIPTION
All utilities print their usage message to stderr,
cmp(1) and getflags(8) should do the same.