### PR TITLE
A: E for acme to be used with $EDITOR

### DIFF
--- a/bin/A
+++ b/bin/A
@@ -1,0 +1,19 @@
+#!/usr/local/plan9/bin/rc
+if(~ $#* 0) fileids=`{9p read acme/new/ctl | awk '{ print $1 }'}
+
+for(file){
+	fileid=`{9p read acme/new/ctl | awk '{ print $1 }'}
+	fileids=($fileids $fileid)
+	echo name `{realpath $file} | 9p write acme/$fileid/ctl
+	echo get | 9p write acme/$fileid/ctl
+}
+
+while(sleep 1){
+	currentids=`{9p read acme/index | awk '{ print $1 }'}
+	fileidstmp=()
+	for(fileid in $fileids){
+		if(~ $fileid $currentids) fileidstmp=($fileidstmp $fileid)
+	}
+	fileids=$fileidstmp
+	if(~ $#fileids 0) exit
+}

--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -38,6 +38,11 @@ acme, win, awd \- interactive text windows
 [
 .I label
 ]
+.LP
+.B A
+[
+.I file
+\&... ]
 .SH DESCRIPTION
 .I Acme
 manages windows of text that may be edited interactively or by external programs.
@@ -703,6 +708,18 @@ windows.  An example definition is
 .EX
 	fn cd { builtin cd $1 && awd $sysname }
 .EE
+.PP
+.I A
+is a shell-level command that can be used as
+.B $EDITOR
+in a Unix environment.
+It opens
+.I acme
+windows for each
+.I file
+and then does not exit until all those
+.I acme
+windows are closed.
 .SS "Applications and guide files
 In the directory
 .B /acme


### PR DESCRIPTION
bug: it opens files that have spaces in their names, but for some reason prints an error