### PR TITLE
make eflag respect bang

### DIFF
--- a/src/cmd/rc/code.c
+++ b/src/cmd/rc/code.c
@@ -162,8 +162,10 @@ outcode(tree *t, int eflag)
 		outcode(c0, eflag);
 		break;
 	case BANG:
-		outcode(c0, eflag);
+		outcode(c0, 0);
 		emitf(Xbang);
+		if(eflag)
+			emitf(Xeflag);
 		break;
 	case PCMD:
 	case BRACE:


### PR DESCRIPTION
setting the `-e` flag already ignores the left side of `||` and `&&`.  This enhances it so that it delays checking the result until after processing the `!`.  This is invaluable when using grep in mkfiles, when you want to invert the pipeline and fail the task. 