### PR TITLE
htmlfmt: add -I flag to suppress printing of image anchors.

### DIFF
--- a/man/man1/fmt.1
+++ b/man/man1/fmt.1
@@ -17,6 +17,8 @@ fmt, htmlfmt \- simple text formatters
 .B -c
 .I charset
 ] [
+.B -I
+] [
 .B -u
 .I url
 ] [
@@ -74,6 +76,10 @@ change the default character set from iso-8859-1 to
 .IR charset .
 This is the character set assumed if there isn't one
 specified by the html itself in a <meta> directive.
+.TP
+.B -I
+When displaying anchors, suppress the printing of
+image anchors.
 .TP
 .BI -u " url
 Use

--- a/src/cmd/htmlfmt/dat.h
+++ b/src/cmd/htmlfmt/dat.h
@@ -27,6 +27,7 @@ struct URLwin
 
 extern	char*	url;
 extern	int		aflag;
+extern	int		Iflag;
 extern	int		width;
 extern	int		defcharset;
 

--- a/src/cmd/htmlfmt/html.c
+++ b/src/cmd/htmlfmt/html.c
@@ -216,7 +216,7 @@ render(URLwin *u, Bytes *t, Item *items, int curanchor)
 			renderbytes(t, "=======\n");
 			break;
 		case Iimagetag:
-			if(!aflag)
+			if(!aflag || Iflag)
 				break;
 			im = (Iimage*)il;
 			if(im->imsrc){

--- a/src/cmd/htmlfmt/main.c
+++ b/src/cmd/htmlfmt/main.c
@@ -7,13 +7,14 @@
 
 char *url = "";
 int aflag;
+int Iflag;
 int width = 70;
 int defcharset;
 
 void
 usage(void)
 {
-	fprint(2, "usage: htmlfmt [-c charset] [-u URL] [-a] [-l length] [file ...]\n");
+	fprint(2, "usage: htmlfmt [-c charset] [-u URL] [-aI] [-l length] [file ...]\n");
 	exits("usage");
 }
 
@@ -32,6 +33,9 @@ main(int argc, char *argv[])
 		p = smprint("<meta charset=\"%s\">", EARGF(usage()));
 		defcharset = charset(p);
 		free(p);
+		break;
+	case 'I':
+		Iflag++;
 		break;
 	case 'l': case 'w':
 		err = EARGF(usage());


### PR DESCRIPTION
This patch adds a -I flag to htmlfmt that suppresses printing of image anchors.

I use 'htmlfmt -aI' as my MH display filter for text/html parts in mail messages. Not printing the image tags eliminates endless noise from people/sites that insist on putting nauseatingly large numbers of pointless image blobs in their messages. -I makes those messages (somewhat) readable.

I'm not wedded to '-I' as the flag, and some might argue a slightly more general mechanism could be useful (e.g. forms display in email is pointless as well, but I have yet to run up against one of those in an email message). But as it is, this patch has made my life more bearable for the last five+ years :-)