### PR TITLE
use plan9port man in plumb/basic

### DIFF
--- a/plumb/basic
+++ b/plumb/basic
@@ -139,7 +139,7 @@ plumb start wmail $0
 # man index entries are synthesized
 type is text
 data matches '([a-zA-Z¡-￿0-9_\-./]+)\(([1-8])\)'
-plumb start rc -c 'man '$2' '$1' >[2=1] | nobs | plumb -i -d edit -a ''action=showdata filename=/man/'$1'('$2')'''
+plumb start rc -c '9 man '$2' '$1' >[2=1] | nobs | plumb -i -d edit -a ''action=showdata filename=/man/'$1'('$2')'''
 
 # start rule for images without known suffixes
 dst is image


### PR DESCRIPTION
@rsc 
use plan9port man in plumb/basic.

man bugs on debian:

9 man 7 regexp:
>          A literal is any non-metacharacter, or a metacharacter (one of .*+?[]()|\^$), or the delimiter preceded by `\'.

man 7 regexp on debian:
>          A  literal is any non-metacharacter, or a metacharacter (one of .*+?[]()|\^$), or the delimiter preceded by


2 more on the same man page:
9 man 7 regexp:
>          A `.'  matches any character.
>
>          A `^' matches the beginning of a line; `$' matches the end of the line.

man 7 regexp on debian:
>       A matches any character.
>
>       A matches the beginning of a line; matches the end of the line.

Possibly other man pages are affected as well.
