### PR TITLE
Makefile: always print the hint to read the README file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 %:
 	@echo read the README file
+all:
 


### PR DESCRIPTION
It always kind of bugged me that a simple `make` invocation didn't print the hint to read the `README`. With this patch applied, the message is always printed. `bmake` got problems when invoked with an argument, but that's nothing the old implementation prevented, so everything stays the same. Amusingly, smaller `make` implementations (e.g. `smake`) don't have problems with that, I guess that's the curse of IB :-)

Anyways, I just think this patch adds convenience and if we keep the Makefile around, why not make it work properly?