### PR TITLE
doc: replace 'README' with 'README.md'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 %:
-	@echo read the README file
+	@echo read the README.md file
 

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo read the README file.
+echo read the README.md file.
 


### PR DESCRIPTION
# Description

By referring to "README.md" instead of just "README", the `configure` and `Makefile` will help ensure that users are directed to the correct file for the documentation.