### PR TITLE
 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue prior to public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to rsc@swtch.com; and/or
+- send us a [private vulnerability report](https://github.com/9fans/plan9port/security/advisories/new)
+
+Please provide the following information in your report:
+
+- Affected programs
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As
+such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Closes #606

As per the linked issue, this PR adds a security policy to the repository.

The policy currently requests that vulnerabilities be reported to Russ Cox's email (copied from the README) or using GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) feature (currently in beta).

If you wish to use another email or just one of these alternatives, let me know and I'll gladly modify the document.