### PR TITLE
libregexp: allow up to 127 captured subexpressions in one regexp

### DIFF
--- a/src/libregexp/regcomp.h
+++ b/src/libregexp/regcomp.h
@@ -5,7 +5,7 @@
 typedef unsigned char uchar;
 #define nelem(x) (sizeof(x)/sizeof((x)[0]))
 
-#define NSUBEXP 32
+#define NSUBEXP 128
 typedef struct Resublist	Resublist;
 struct	Resublist
 {


### PR DESCRIPTION
128 counting with the entire expression match (`$0`).

The most straightforward way to address point 2 from #565 (in preparation for #610). Please let me know if 128 is not a good candidate for this bound, or if dynamic allocation would be preferable instead (as discussed in the linked issue).