### PR TITLE
plumber: increase NMATCHSUBEXP up to 100

### DIFF
--- a/src/cmd/plumb/plumber.h
+++ b/src/cmd/plumb/plumber.h
@@ -54,7 +54,7 @@ struct Ruleset
 
 enum
 {
-	NMATCHSUBEXP = 32	/* bounded by ../../libregexp/regcomp.h:/NSUBEXP */
+	NMATCHSUBEXP = 100	/* bounded by ../../libregexp/regcomp.h:/NSUBEXP */
 };
 
 struct Exec


### PR DESCRIPTION
Thus up to two-digit subexpression match variables are supported (`$1` through `$99`) in addition to the entire expression match (`$0`).

The most straightforward way to fix #565 in regards to point 2.

**Depends on #609 being merged first!**