### PR TITLE
libregexp: allow up to 128 character classes in one regexp

### DIFF
--- a/include/regexp9.h
+++ b/include/regexp9.h
@@ -1,7 +1,7 @@
 #ifndef _REGEXP9_H_
 #define _REGEXP9_H_ 1
 #if defined(__cplusplus)
-extern "C" { 
+extern "C" {
 #endif
 
 #ifdef AUTOLIB
@@ -61,7 +61,7 @@ struct Reinst{
  */
 struct Reprog{
 	Reinst	*startinst;	/* start pc */
-	Reclass	class[16];	/* .data */
+	Reclass	class[128];	/* .data */
 	Reinst	firstinst[5];	/* .text */
 };
 


### PR DESCRIPTION
The most straightforward way to fix #565 in regards to point 3. Please let me know if 128 is not a good candidate for this bound, or if dynamic allocation would be preferable instead (as discussed in the linked issue).