### PR TITLE
Dockerfile to build plan9port in Alpine Linux container

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=false
+* text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@ FROM alpine:3.18
 RUN apk add \
     build-base \
     expat \
-    git-perl \
-    libssl3 \
-    libretls \
     linux-headers \
-    make
+    make \
+    perl
 
 ENV PLAN9=/usr/local/plan9
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:3.18
 
+RUN apk update --no-cache
+
 RUN apk add \
-    build-base \
-    expat \
+    gcc \
+    libc-dev \
     linux-headers \
-    make \
     perl
 
 ENV PLAN9=/usr/local/plan9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.18
+
+RUN apk add \
+    build-base \
+    expat \
+    git-perl \
+    libssl3 \
+    libretls \
+    linux-headers \
+    make
+
+ENV PLAN9=/usr/local/plan9
+
+WORKDIR $PLAN9
+RUN git clone --depth=1 https://github.com/9fans/plan9port.git .
+RUN ./INSTALL
+
+ENV PATH=$PATH:$PLAN9/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add \
 ENV PLAN9=/usr/local/plan9
 
 WORKDIR $PLAN9
-RUN git clone --depth=1 https://github.com/9fans/plan9port.git .
+COPY . .
 RUN ./INSTALL
 
 ENV PATH=$PATH:$PLAN9/bin


### PR DESCRIPTION
Hi all.  
I'm adding this for others to show which packages are definitely needed in the host environment to build plan9port, and maybe even spin up a container for themselves easily.  When building from a docker file, certain errors seem to be suppressed. I hadn't noticed perl was being used at first.  So it is possible I've unwittingly removed something essential.  But rc seems to work on the surface.

A .gitattributes file is also included.  This reduces the pain for Windows users building Docker images from a local plan9port repo (otherwise Git may change the line endings to crlf).

I haven't had much joy with https://pkgs.alpinelinux.org/package/edge/community/x86/plan9port (perhaps I hadn't carried out a final configuration step, but it appears some build directories are hardcoded into it). 

This image did work: https://hub.docker.com/r/plan9d/plan9port but I've no clue what was in the hashes it builds from, so I reverse engineered it by diffing apk list--installed with alpine:build-base, and afterwards stripped out the packages unnecessary, simply to compile plan9port, by trial and error.