### PR TITLE
use grep -E instead of egrep

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -53,7 +53,7 @@ quiet()
 	ignore=$ignore'|expanded from macro'
 
 	grep -v '__p9l_autolib_' $1 |
-	egrep -v "$ignore" |
+	grep -E -v "$ignore" |
 	sed 's/ .first use in this function.$//; s/\"\([^\"][^\"]*\)\", line \([0-9][0-9]*\)/\1:\2/g' |
 	$(which uniq) 1>&2  # avoid built-in uniq on SunOS
 }

--- a/bin/9l
+++ b/bin/9l
@@ -146,7 +146,7 @@ then
 					grep '__p9l_autolib_[a-zA-Z0-9+-]*' |
 					sed 's/.*__p9l_autolib_//; s/:.*//' |
 					sort -u |
-					egrep -v '^(thread|draw)$'
+					grep -E -v '^(thread|draw)$'
 				`
 				a="$a $b"
 			done
@@ -329,8 +329,8 @@ fi
 
 xtmp="${TMPDIR-/tmp}/9l.$$.$USER.out"
 xxout() {
-	sed 's/.*: In function `[^:]*: *//' $xtmp | egrep . |
-	egrep -v 'is (often|almost always) misused|is dangerous, better use|text-based stub'
+	sed 's/.*: In function `[^:]*: *//' $xtmp | grep -E . |
+	grep -Ev 'is (often|almost always) misused|is dangerous, better use|text-based stub'
 	rm -f $xtmp
 }
 

--- a/src/cmd/auxstats/mkfile
+++ b/src/cmd/auxstats/mkfile
@@ -12,6 +12,6 @@ HFILES=\
 
 <$PLAN9/src/mkone
 
-KVM=`{if uname |egrep 'BSD' | egrep -v 'OpenBSD' >/dev/null; then echo -lkvm; fi}
+KVM=`{if uname |grep -E 'BSD' | grep -Ev 'OpenBSD' >/dev/null; then echo -lkvm; fi}
 LDFLAGS=$LDFLAGS $KVM
 

--- a/src/cmd/devdraw/mkwsysrules.sh
+++ b/src/cmd/devdraw/mkwsysrules.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "x$WSYSTYPE" = "x" ]; then
 	if [ "x`uname`" = "xDarwin" ]; then
-		if sw_vers | egrep 'ProductVersion:	(10\.[0-9]\.|10\.1[012])$' >/dev/null; then
+		if sw_vers | grep -E 'ProductVersion:	(10\.[0-9]\.|10\.1[012])$' >/dev/null; then
 			echo 1>&2 'OS X 10.12 and older are not supported'
 			exit 1
 		fi

--- a/src/cmd/mkfile
+++ b/src/cmd/mkfile
@@ -1,11 +1,11 @@
 <$PLAN9/src/mkhdr
 
-TARG=`ls *.[cy] *.lx | egrep -v "\.tab\.c$|^x\." | sed 's/\.[cy]//; s/\.lx//'`
+TARG=`ls *.[cy] *.lx | grep -Ev "\.tab\.c$|^x\." | sed 's/\.[cy]//; s/\.lx//'`
 
 <$PLAN9/src/mkmany
 
 BUGGERED='CVS|faces|factotum|lp|ip|mailfs|upas|vncv|mnihongo|mpm|index|u9fs|secstore|smugfs|snarfer'
-DIRS=lex `ls -l |sed -n 's/^d.* //p' |egrep -v "^($BUGGERED)$"|egrep -v '^lex$'` $FONTSRV
+DIRS=lex `ls -l |sed -n 's/^d.* //p' |grep -Ev "^($BUGGERED)$"|grep -Ev '^lex$'` $FONTSRV
 
 <$PLAN9/src/mkdirs
 

--- a/src/cmd/rc/checkparse
+++ b/src/cmd/rc/checkparse
@@ -10,7 +10,7 @@ files="$@"
 if [ $# = 0 ]; then
 	files=$(echo ./test.rc;
 		grep -l '^#!/usr/local/plan9/bin/rc' /usr/local/plan9/bin/{*,*/*} 2>/dev/null;
-		grep -R -l '^#!/bin/rc' $HOME/pub/plan9 | egrep -v 'plan9/(lib/(oui|pci)|sys/man|sys/lib/man|sys/lib/scsicodes)' 2>/dev/null)
+		grep -R -l '^#!/bin/rc' $HOME/pub/plan9 | grep -Ev 'plan9/(lib/(oui|pci)|sys/man|sys/lib/man|sys/lib/scsicodes)' 2>/dev/null)
 fi
 
 for i in $files

--- a/src/mkfile
+++ b/src/mkfile
@@ -1,7 +1,7 @@
 <mkhdr
 
 BUGGERED='fs|fmt|utf'
-LIBDIRS=`ls -ld lib* | sed -n 's/^d.* //p' |egrep -v "^lib($BUGGERED)$"`
+LIBDIRS=`ls -ld lib* | sed -n 's/^d.* //p' |grep -Ev "^lib($BUGGERED)$"`
 
 DIRS=\
 	$LIBDIRS\


### PR DESCRIPTION
I noticed *egrep* always output warning:

> egrep: warning: egrep is obsolescent; using grep -E

I heared this warning may be introduced in GNU Grep v3.8.