### PR TITLE
libdraw: fix subfont scaling

### DIFF
--- a/src/libdraw/getsubfont.c
+++ b/src/libdraw/getsubfont.c
@@ -122,7 +122,7 @@ scalesubfont(Subfont *f, int scale)
 	f->height *= scale;
 	f->ascent *= scale;
 
-	for(j=0; j<f->n; j++) {
+	for(j=0; j<=f->n; j++) {
 		f->info[j].x *= scale;
 		f->info[j].top *= scale;
 		f->info[j].bottom *= scale;


### PR DESCRIPTION
A subfont struct with n chars has n+1 Fontchars in its info member.

Currently, when a subfont is scaled only n info entries are updated. Because of that, after scaling the last character uses an incorrect part of the subfont image is used for its glyph.

This pull request modifies scalesubfont() so all n+1 entries of info are scaled.

(All n+1 Fontchar entries appear necessary, see `_unpackinfo()` in `src/libdraw/readsubfont.c` .)

**Example**:

Using `lucsans/euro.8.font` font, whose first subfont range covers Unicode points 0x0000 through 0x00FF.

_Before code change_: on a non-HiDPI screen Unicode point 0x00FF "Latin Small Letter Y with Diaeresis" (ÿ) displays correctly, but the same character appears as an empty space when the font is scaled to 2x.

![acme-pre](https://github.com/9fans/plan9port/assets/17259213/84a32a44-c01a-498e-8a0e-6bc92b7b4bd3)

_After code change_: the character appears as expected post-scaling.

![acme-post](https://github.com/9fans/plan9port/assets/17259213/01c34565-2015-4715-a3c2-18c5bc0fa1ba)