### PR TITLE
libframe: Match the color of tick

### DIFF
--- a/src/libframe/frinit.c
+++ b/src/libframe/frinit.c
@@ -52,7 +52,7 @@ frinittick(Frame *f)
 	/* background color */
 	draw(f->tick, f->tick->r, f->cols[BACK], nil, ZP);
 	/* vertical line */
-	draw(f->tick, Rect(f->tickscale*(FRTICKW/2), 0, f->tickscale*(FRTICKW/2+1), ft->height), f->display->black, nil, ZP);
+	draw(f->tick, Rect(f->tickscale*(FRTICKW/2), 0, f->tickscale*(FRTICKW/2+1), ft->height), f->cols[TEXT], nil, ZP);
 	/* box on each end */
 	draw(f->tick, Rect(0, 0, f->tickscale*FRTICKW, f->tickscale*FRTICKW), f->cols[TEXT], nil, ZP);
 	draw(f->tick, Rect(0, ft->height-f->tickscale*FRTICKW, f->tickscale*FRTICKW, ft->height), f->cols[TEXT], nil, ZP);


### PR DESCRIPTION
Previously the vertical bar in tick was always black; fine if you use the standard black-on-white for everything, but any attempt to add a dark mode ran into trouble with the tick being half hard-coded black, half the new text color.

Using this new color matches the code around it.