### PR TITLE
dist/main.html: remove dead link to Belorussian translation

### DIFF
--- a/dist/main.html
+++ b/dist/main.html
@@ -35,8 +35,6 @@ Edit ./^$/,s/<Table/<table border=0 cellspacing=0 cellpadding=0 width=100%/g
       <a href="https://github.com/9fans/plan9port">github</a>
       |
       <a href="unix/">unix</a>
-      |
-      <a href="http://webhostinggeeks.com/science/plan9port-be">Belorussian</a>
     </center>
     <table border=0 cellspacing=0 cellpadding=0 width=100%><tr height=10><td></table>
     Plan 9 from User Space (aka plan9port)


### PR DESCRIPTION
According to web.archive.org this link is dead since 2012/2013. According to original issue (http://codereview.appspot.com/4251044) that translation could be a machine translation.