### PR TITLE
acme: have Dump save both low and high DPI fontnames

### DIFF
--- a/src/cmd/acme/rows.c
+++ b/src/cmd/acme/rows.c
@@ -319,7 +319,7 @@ rowdump(Row *row, char *file)
 	int i, j, fd, m, n, start, dumped;
 	uint q0, q1;
 	Biobuf *b;
-	char *buf, *a, *fontname;
+	char *buf, *a, *fontname, *fontfmt, *fontnamelo, *fontnamehi;
 	Rune *r;
 	Column *c;
 	Window *w, *w1;
@@ -394,9 +394,17 @@ rowdump(Row *row, char *file)
 					if(w1->nopen[QWevent])
 						goto Continue2;
 				}
-			fontname = "";
-			if(t->reffont->f != font)
-				fontname = t->reffont->f->name;
+			fontfmt = "%s";
+			fontnamelo = "";
+			fontnamehi = nil;
+			if(t->reffont->f != font){
+				fontnamelo = t->reffont->f->lodpi->name;
+				if(t->reffont->f->hidpi != nil){
+					fontfmt = "%s,%s";
+					fontnamehi = t->reffont->f->hidpi->name;
+				}
+			}
+			fontname = smprint(fontfmt, fontnamelo, fontnamehi);
 			if(t->file->nname)
 				a = runetobyte(t->file->name, t->file->nname);
 			else
@@ -428,6 +436,7 @@ rowdump(Row *row, char *file)
 					100.0*(w->r.min.y-c->r.min.y)/Dy(c->r),
 					w->body.file->b.nc, fontname);
 			}
+			free(fontname);
 			free(a);
 			winctlprint(w, buf, 0);
 			Bwrite(b, buf, strlen(buf));


### PR DESCRIPTION
Instead of only saving a window's currently displayed font's name (`t->reffont->f->name`) to the dump file (the current implementation), have Acme's Dump command save that window's combined low DPI and high DPI font names (`t->reffont->f->lodpi->name` and `t->reffont->f->hidpi->name`) when both are available.

This patch enables Acme dumps to better retain window font state.

In particular, it addresses the following font display quirk when using `Dump` and `Load` in Acme on high-DPI screens (200 DPI or more, like macOS Retina screens) without this patch, shown as an example:

1. Suppose we are using Acme on a high DPI screen, say a Retina MacBook screen.
2. Open a non-empty text file, say `/tmp/abc.txt`, in Acme on a high DPI screen type.
3. Execute `Font /mnt/font/AndaleMono/15a/font`. This font is treated as the low DPI font and Acme automatically doubles its point size to `/mnt/font/AndaleMono/30a/font` as the high DPI font. Since we are using a high DPI screen, the high DPI font is displayed.
4. Execute `Dump` to save window state to a dump file `~/acme.dump`. The saved font for the `/tmp/abc.txt` window in the dump file is `/mnt/font/AndaleMono/30a/font` as that's the displayed font.
5. Close then start a fresh instance of Acme.
6. Execute `Load` to restore window state from `~/acme.dump`. The saved font name for the `/tmp/abc.txt` window, `/mnt/font/AndaleMono/30a/font`, is treated as a low DPI font so it is automatically doubled to in point size (i.e., `/mnt/font/AndaleMono/60a/font` is used) for use as the high DPI font, and since we are on a high DPI screen that 60pt font is displayed.

In the example, the displayed font in the `/tmp/abc.txt` window is clearly too large. That is, font display state was restored incorrectly.
   
With this patch applied, in step 4 of the example, the saved font name for the `/tmp/abc.txt` window in the dump file is now 
`/mnt/font/AndaleMono/15a/font,/mnt/font/AndaleMono/30a/font`. So, on `Load` in step 6, the high DPI font `/mnt/font/AndaleMono/30a/font` is used to display text in the file window. That is, display font state was restored correctly.