### PR TITLE
9l: silence the 'ignoring duplicate libraries' warning on macOS

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test -f $PLAN9/config && . $PLAN9/config
+test -f "$PLAN9/config" && . "$PLAN9/config"
 usegcc()
 {
 	cc=${CC9:-gcc}
@@ -52,7 +52,7 @@ quiet()
 	ignore=$ignore'|warn_unused_result'
 	ignore=$ignore'|expanded from macro'
 
-	grep -v '__p9l_autolib_' $1 |
+	grep -v '__p9l_autolib_' "$1" |
 	egrep -v "$ignore" |
 	sed 's/ .first use in this function.$//; s/\"\([^\"][^\"]*\)\", line \([0-9][0-9]*\)/\1:\2/g' |
 	$(which uniq) 1>&2  # avoid built-in uniq on SunOS
@@ -143,10 +143,10 @@ case "$tag" in
 	exit 1
 esac
 
-# N.B. Must use temp file to avoid pipe; pipe loses status.
+# Must use temp file to avoid pipe; pipe loses status.
 xtmp=${TMPDIR-/tmp}/9c.$$.$USER.out
-$cc -DPLAN9PORT -I$PLAN9/include $cflags "$@" 2>$xtmp
+$cc -DPLAN9PORT -I"$PLAN9/include" $cflags "$@" 2>"$xtmp"
 status=$?
-quiet $xtmp
-rm -f $xtmp
+quiet "$xtmp"
+rm -f "$xtmp"
 exit $status

--- a/bin/9l
+++ b/bin/9l
@@ -333,6 +333,8 @@ quiet()
 	ignore=$ignore'|is (often|almost always) misused'
 	ignore=$ignore'|is dangerous, better use'
 	ignore=$ignore'|text-based stub'
+	# macOS linker is incessant about reoccurring -l9, -lsec, -lthread:
+	ignore=$ignore'|ld: warning: ignoring duplicate libraries:'
 
 	sed 's/.*: In function `[^:]*: *//' "$1" |
 	egrep -v "$ignore"

--- a/bin/9l
+++ b/bin/9l
@@ -2,7 +2,7 @@
 
 [ "$1" = "" ] && exit 1
 
-test -f $PLAN9/config && . $PLAN9/config
+test -f "$PLAN9/config" && . "$PLAN9/config"
 libsl=""
 frameworks=""
 doautolib=true
@@ -324,23 +324,28 @@ esac
 
 if $verbose
 then
-	echo $ld -L$PLAN9/lib "$@" $libsl $extralibs $frameworks
+	echo $ld -L"$PLAN9/lib" "$@" $libsl $extralibs $frameworks
 fi
 
-xtmp="${TMPDIR-/tmp}/9l.$$.$USER.out"
-xxout() {
-	sed 's/.*: In function `[^:]*: *//' $xtmp | egrep . |
-	egrep -v 'is (often|almost always) misused|is dangerous, better use|text-based stub'
-	rm -f $xtmp
+quiet()
+{
+	ignore='^$'
+	ignore=$ignore'|is (often|almost always) misused'
+	ignore=$ignore'|is dangerous, better use'
+	ignore=$ignore'|text-based stub'
+
+	sed 's/.*: In function `[^:]*: *//' "$1" |
+	egrep -v "$ignore"
 }
 
-if $ld -L$PLAN9/lib "$@" $libsl $extralibs $frameworks >$xtmp 2>&1
+# Must use temp file to avoid pipe; pipe loses status.
+xtmp=${TMPDIR-/tmp}/9l.$$.$USER.out
+$ld -L"$PLAN9/lib" "$@" $libsl $extralibs $frameworks >"$xtmp" 2>&1
+status=$?
+quiet "$xtmp"
+rm -f "$xtmp"
+if [ "$status" -ne 0 ]
 then
-	xxout
-	exit 0
-else
-	xxout
-	rm -f $target
-	exit 1
+	rm -f "$target"
 fi
-
+exit $status


### PR DESCRIPTION
Ever since the update of Xcode tools to version 15.1.0 in macOS 14.2, `ld` started to warn every time the same library is given more than once in its arguments. Since `-l9`, `-lsec`, `-lthread` frequently reoccur in Plan 9 Port linker invocations, this new behavior fills the `INSTALL` output with this useless warning.

Add it to the ignore list that is used to filter out the linker output. While at it, make the mechanics of warning-silencing in `9l` uniform with `9c` (and make quoting of variable substitutions a bit more consistent in both, along the way).