### PR TITLE
.gitignore: add bin/mntgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ bin/mk
 bin/mk9660
 bin/mkdir
 bin/mklatinkbd
+bin/mntgen
 bin/mtime
 bin/namespace
 bin/ndbipquery


### PR DESCRIPTION
#637 introduced a new binary, but did not add it to `.gitignore`.