### PR TITLE
Auxstat: Fixed ether, user, sys, and cpu outputs on Linux.

### DIFF
--- a/src/cmd/auxstats/Linux.c
+++ b/src/cmd/auxstats/Linux.c
@@ -201,9 +201,9 @@ xstat(int first)
 		if(ntok < 2)
 			continue;
 		if(strcmp(tok[0], "cpu") == 0 && ntok >= 5){
-			long long user = atoll(tok[1]) / numcores;
-			long long sys = atoll(tok[3]) / numcores;
-			long long cpu = user + sys;
+			const long long user = atoll(tok[1]) / numcores;
+			const long long sys = atoll(tok[3]) / numcores;
+			const long long cpu = user + sys;
 			Bprint(&bout, "user %lld 100\n", user);
 			Bprint(&bout, "sys %lld 100\n", sys);
 			Bprint(&bout, "cpu %lld 100\n", cpu);

--- a/src/cmd/auxstats/Linux.c
+++ b/src/cmd/auxstats/Linux.c
@@ -182,9 +182,9 @@ xstat(int first)
 		readfile(fd);
 		for(i=0; i<nline; i++){
 			tokens(i);
-			if(ntok < 2)
+			if(ntok < 3)
 				continue;
-			if(strcmp(tok[0], "siblings") == 0 && ntok >= 2){
+			if(strcmp(tok[0], "siblings") == 0 && ntok >= 3){
 				numcores = atoll(tok[2]);
 				break;
 			}

--- a/src/cmd/auxstats/Linux.c
+++ b/src/cmd/auxstats/Linux.c
@@ -143,7 +143,7 @@ xnet(int first)
 		tokens(i);
 		if(ntok < 8+8)
 			continue;
-		if(regexec(netdev, tok[0], nil, 0) != 1)
+		if(regexec(netdev, tok[0], nil, 0) != 0)
 			continue;
 		inb = atoll(tok[1]);
 		oub = atoll(tok[9]);


### PR DESCRIPTION
1) Ether output was not working at all due to expecting regexec() to return 1 (as in plan9) instead of 0 when successful. 
2) Cpu/user/sys stats (as seen in the 9 program stats, for example) were often maxed out due to not scaling to number of logical cpu cores.