### PR TITLE
web: Remove redundant echo

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -68,7 +68,6 @@ else
 		else
 			i=`echo $i | tr -d ' '`
 		fi
-		echo p "$i"
 		plumb1 $i
 	done
 fi


### PR DESCRIPTION
I noticed that a message was printed whenever I called the `web` program. It was introduced in https://github.com/9fans/plan9port/commit/279091480876733721672e457bc9233a3539358b and I assume it's a remenant from debugging.