### PR TITLE
Check potential null pointer returned by strdup

### DIFF
--- a/src/cmd/acid/lex.c
+++ b/src/cmd/acid/lex.c
@@ -645,6 +645,8 @@ enter(char *name, int t)
 	s = gmalloc(sizeof(Lsym));
 	memset(s, 0, sizeof(Lsym));
 	s->name = strdup(name);
+	if(s->name == 0)
+		fatal("no memory");
 
 	s->hash = hash[h];
 	hash[h] = s;

--- a/src/cmd/auth/secstore/secstored.c
+++ b/src/cmd/auth/secstore/secstored.c
@@ -218,21 +218,32 @@ remoteIP(char *ldir)
 {
 	int fd, n;
 	char rp[100], ap[500];
+	char *ret;
 
 	snprint(rp, sizeof rp, "%s/remote", ldir);
 	fd = open(rp, OREAD);
-	if(fd < 0)
-		return strdup("?!?");
+	if(fd < 0){
+		ret = strdup("?!?");
+		if(ret == nil)
+			sysfatal("no memory");
+		return ret;
+	}
 	n = read(fd, ap, sizeof ap);
 	if(n <= 0 || n == sizeof ap){
 		fprint(2, "error %d reading %s: %r\n", n, rp);
-		return strdup("?!?");
+		ret = strdup("?!?");
+		if(ret == nil)
+			sysfatal("no memory");
+		return ret;
 	}
 	close(fd);
 	ap[n--] = 0;
 	if(ap[n] == '\n')
 		ap[n] = 0;
-	return strdup(ap);
+	ret = strdup(ap);
+	if(ret == nil)
+		sysfatal("no memory");
+	return ret;
 }
 
 static int

--- a/src/cmd/hget.c
+++ b/src/cmd/hget.c
@@ -275,6 +275,11 @@ crackurl(URL *u, char *s)
 		*p = '/';
 	}
 
+	if(u->host == nil || u->page == nil){
+		werrstr("Memory allocation failed for URL host or page.");
+		return -1;
+	}
+
 	if(p = strchr(u->host, ':')) {
 		*p++ = 0;
 		u->port = p;
@@ -795,6 +800,10 @@ hhuri(char *p, URL *u, Range *r)
 	if(*p != '<')
 		return;
 	u->redirect = strdup(p+1);
+	if(u->redirect == nil){
+		sysfatal("Memory allocation failed.");
+	}
+		
 	p = strchr(u->redirect, '>');
 	if(p != nil)
 		*p = 0;
@@ -806,6 +815,9 @@ hhlocation(char *p, URL *u, Range *r)
 	USED(r);
 
 	u->redirect = strdup(p);
+	if(u->redirect == nil){
+		sysfatal("Memory allocation failed.");
+	}
 }
 
 void

--- a/src/cmd/ls.c
+++ b/src/cmd/ls.c
@@ -130,6 +130,10 @@ ls(char *s, int multi)
 			*p = 0;
 			/* restore original name; don't use result of stat */
 			dirbuf[ndir].d->name = strdup(p+1);
+			if(dirbuf[ndir].d->name == nil){
+				fprint(2, "ls: malloc fail\n");
+				return 1;
+			}
 		}
 		ndir++;
 	}

--- a/src/cmd/news.c
+++ b/src/cmd/news.c
@@ -111,6 +111,10 @@ read_dir(int update)
 			n_list[n_count].length = 0;
 			n_count++;
 			free(d);
+			if(n_list[n_count-1].name == nil){
+				fprint(2, "Memory allocation failed");
+				exits("Memory allocation failed");
+			}
 		}
 		if(update) {
 			fd = create(newstime, OWRITE, 0644);

--- a/src/cmd/split.c
+++ b/src/cmd/split.c
@@ -39,12 +39,24 @@ main(int argc, char *argv[])
 		break;
 	case 'e':
 		pattern = strdup(EARGF(usage()));
+		if(pattern == nil){
+			fprint(2, "split: out of memory\n");
+			exits("memory");
+		}
 		break;
 	case 'f':
 		stem = strdup(EARGF(usage()));
+		if(stem == nil){
+			fprint(2, "split: out of memory\n");
+			exits("memory");
+		}
 		break;
 	case 's':
 		suffix = strdup(EARGF(usage()));
+		if(suffix == nil){
+			fprint(2, "split: out of memory\n");
+			exits("memory");
+		}
 		break;
 	case 'x':
 		xflag++;

--- a/src/cmd/tar.c
+++ b/src/cmd/tar.c
@@ -871,6 +871,11 @@ cantcreate(char *s, int mode)
 		/* save */
 		free(last);
 		last = strdup(s);
+		if(last == nil){
+			fprint(2, "Memory allocation failed.\n");
+			return;
+		}
+			
 	}
 	fprint(2, "%s: can't create %s: %r\n", argv0, s);
 }


### PR DESCRIPTION
The lib function `strdup` may return null pointer on memory allocation failures.

I added null pointer checks to unchecked `strdup` calls.