### PR TITLE
cmd/lex fix Segmentation fault

### DIFF
--- a/src/cmd/lex/parser.y
+++ b/src/cmd/lex/parser.y
@@ -620,7 +620,7 @@ yylex(void)
 	if(debug)
 		Bprint(&fout,"\n/*this comes from section three - debug */\n");
 # endif
-	while(getl(buf) && !eof)
+	while(!eof && getl(buf))
 		Bprint(&fout,"%s\n",(char*)buf);
 	return(freturn(0));
 }


### PR DESCRIPTION
If the file does not end with new line, segmentation fault occurs.
[Because input file is already closed](https://github.com/9fans/plan9port/blob/61e362add9e1485bec1ab8261d729016850ec270/src/cmd/lex/sub1.c#L290).

```
// input.l
%{
%}
%%
[0-9]+          return NUMBER;
%%
```

```
#0  0x000055555555c8e0 in Bgetc (bp=0x0) at bgetc.c:10
#1  0x000055555555986c in gch () at sub1.c:277
#2  0x0000555555559960 in getl (p=p@entry=0x55555556a6a0 <buf> "%%") at sub1.c:10
#3  0x0000555555556f9a in yylex ()
    at /home/xxxx/src/plan9port/src/cmd/lex/parser.y:623
#4  0x00005555555581b9 in yylex1 ()
    at /home/xxxx/src/plan9port/src/cmd/lex/parser.y:823
#5  0x0000555555558515 in yyparse ()
    at /home/xxxx/src/plan9port/src/cmd/lex/parser.y:951
#6  0x00005555555567c3 in p9main (argc=1, argv=0x7fffffffe090) at lmain.c:149
#7  0x0000555555556359 in main (argc=<optimized out>, argv=<optimized out>)
```