### PR TITLE
devdraw: fix cursor warping under XWayland

### DIFF
--- a/src/cmd/devdraw/mkwsysrules.sh
+++ b/src/cmd/devdraw/mkwsysrules.sh
@@ -49,7 +49,7 @@ echo 'X11='$X11
 echo 'X11H='$X11H
 
 if [ $WSYSTYPE = x11 ]; then
-	echo 'CFLAGS=$CFLAGS '$X11H
+	echo 'CFLAGS=$CFLAGS '$X11H -lXfixes
 	echo 'HFILES=$HFILES $XHFILES'
 	XO=`ls x11-*.c 2>/dev/null | sed 's/\.c$/.o/'`
 	echo 'WSYSOFILES=$WSYSOFILES '$XO

--- a/src/cmd/devdraw/x11-inc.h
+++ b/src/cmd/devdraw/x11-inc.h
@@ -16,6 +16,7 @@
 #include <X11/keysym.h>
 #include <X11/IntrinsicP.h>
 #include <X11/StringDefs.h>
+#include <X11/extensions/Xfixes.h>
 #ifdef SHOWEVENT
 #include <stdio.h>
 #include "../rio/showevent/ShowEvent.c"

--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -1384,8 +1384,10 @@ rpc_setmouse(Client *client, Point p)
 	Xwin *w = (Xwin*)client->view;
 
 	xlock();
+	XFixesHideCursor(_x.display, w->drawable);
 	XWarpPointer(_x.display, None, w->drawable, 0, 0, 0, 0, p.x, p.y);
 	XFlush(_x.display);
+	XFixesShowCursor(_x.display, w->drawable);
 	xunlock();
 }
 


### PR DESCRIPTION
If devdraw is run under Wayland via XWayland cursor warping doesn't work.

However it's possible to move the cursor if it's not visible: https://github.com/libsdl-org/SDL/issues/9539
I modified devdraw `rpc_setmouse` function to hide cursor before calling `XWarpPointer()` and show it afterwards.

Hiding and showing cursor is handled by XFixes extenstion which requirers including `X11/extensions/Xfixes.h` header and adding `-lXfixes` to CFLAGS.