### PR TITLE
man: don't paginate when using nroff

### DIFF
--- a/bin/man
+++ b/bin/man
@@ -18,6 +18,7 @@ fn roff {
 	}
 	if not {
 		Nflag=-N
+		Lflag='-rL1000i'
 	}
 	if(~ $x *eqn*)
 		preproc=($preproc eqn)
@@ -26,15 +27,15 @@ fn roff {
 
 	switch($#preproc) {
 		case 0
-			{echo -n $FONTS; cat $2< /dev/null} | troff $Nflag -$MAN 
+			{echo -n $FONTS; cat $2< /dev/null} | troff $Nflag $Lflag -$MAN 
 		case 1
-			{echo -n $FONTS; cat $2< /dev/null} | $preproc | troff $Nflag -$MAN
+			{echo -n $FONTS; cat $2< /dev/null} | $preproc | troff $Nflag $Lflag -$MAN
 		case 2
-			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | troff $Nflag -$MAN
+			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | troff $Nflag $Lflag -$MAN
 		case 3
-			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | $preproc(3) | | troff $Nflag -$MAN
+			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | $preproc(3) | | troff $Nflag $Lflag -$MAN
 		case *
-			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | $preproc(3) | | $preproc(4) | troff $Nflag -$MAN
+			{echo -n $FONTS; cat $2< /dev/null} | $preproc(1) | $preproc(2) | $preproc(3) | | $preproc(4) | troff $Nflag $Lflag -$MAN
 	}
 }
 

--- a/tmac/tmac.an
+++ b/tmac/tmac.an
@@ -479,7 +479,9 @@
 .if t \{.ds R ®
 .ds S \s\n()S
 ..\}
-.if n \{.nr )L 11i
+.if n \{.ie \nL<=0 .nr )L 11i
+.el \{.nr )L \nLu
+.nr V 0\}
 .nr LL 6.5i
 .nr )O .463i
 .if '\*(.T'think' \{.nrLL 80n


### PR DESCRIPTION
This tells bin/man to set the register L to very high to avoid pagination and updates tmac/tmac.an to use that value, if it's set, to set the page length. This is per Plan 9's rc/bin/man and sys/lib/tmac/tmac.an.