### PR TITLE
Add `-lresolv` on Darwin

### DIFF
--- a/bin/9l
+++ b/bin/9l
@@ -31,6 +31,7 @@ case "$tag" in
 	;;
 *Darwin*)
 	ld="${CC9:-gcc} -m64 $CC9FLAGS"
+	extralibs="-lresolv"
 	;;
 *SunOS*)
 	ld="${CC9:-cc} -g $CC9FLAGS"


### PR DESCRIPTION
On macOS 15.2, -lresolv is required to resolve symbols like `_res_9_dn_expand`:

```sh
; cd src/cmd/upas
; mk install
for i in common smtp alias fs ned q send marshal vf misc
do
	(cd $i; echo cd `pwd`';' mk $MKFLAGS install; mk $MKFLAGS install)
done
cd /Users/cptaffe/src/plan9port/src/cmd/upas/common; mk install
mk: 'install' is up to date
cd /Users/cptaffe/src/plan9port/src/cmd/upas/smtp; mk install
for i in smtp smtpd
do
	mk $MKFLAGS $i.install
done
9c -I../common -DSPOOL="/Users/cptaffe/src/plan9port/mail" rfc822.tab.c
9l -o o.smtp rfc822.tab.o mxdial.o smtp.o ../common/libcommon.a
Undefined symbols for architecture arm64:
  "_res_9_dn_expand", referenced from:
      _doquery in libndb.a[18](sysdnsquery.o)
      _doquery in libndb.a[18](sysdnsquery.o)
      _rrunpack in libndb.a[18](sysdnsquery.o)
  "_res_9_search", referenced from:
      _doquery in libndb.a[18](sysdnsquery.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
mk: 9l -o o.smtp ...  : exit status=exit(1)
mk: for i in ...  : exit status=exit(1)
mk: for i in ...  : exit status=exit(1)
```