### PR TITLE
AIX fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -65,6 +65,9 @@ DragonFly|*BSD)
 	echo "CFLAGS='-pthread'" >> $PLAN9/config
 	awk=awk
 	;;
+AIX)
+	awk=gawk
+	;;
 *)
 	awk=awk
 	;;

--- a/INSTALL
+++ b/INSTALL
@@ -118,8 +118,8 @@ fi
 if [ `uname` != Darwin ]; then
 	# Determine whether fontsrv X11 files are available.
 	rm -f a.out
-	cc -o a.out -c -Iinclude -I/usr/include -I/usr/local/include -I/usr/include/freetype2 -I/usr/local/include/freetype2 \
-	    -I/usr/X11R7/include -I/usr/X11R7/include/freetype2 \
+	9c -o a.out -c -Iinclude -I/usr/include -I/usr/local/include -I/usr/include/freetype2 -I/usr/local/include/freetype2 \
+	    -I/usr/X11R7/include -I/usr/X11R7/include/freetype2 -I/opt/freeware/include -I/opt/freeware/include/freetype2 \
 	    -I/usr/X11R6/include -I/usr/X11R6/include/freetype2 src/cmd/fontsrv/x11.c >/dev/null 2>&1
 	if [ -f a.out ]; then
 		echo "	fontsrv dependencies found."

--- a/INSTALL
+++ b/INSTALL
@@ -37,6 +37,7 @@ PATH=/bin:/usr/bin:$PLAN9/bin:$PATH export PATH
 [ -z "$PLAN9_TARGET" ] && PLAN9_TARGET="$PLAN9"
 export PLAN9_TARGET
 
+CCVERSFLAG=''
 case `uname` in
 SunOS)
 	awk=nawk
@@ -67,6 +68,7 @@ DragonFly|*BSD)
 	;;
 AIX)
 	awk=gawk
+	CCVERSFLAG=-qversion
 	;;
 *)
 	awk=awk
@@ -139,7 +141,7 @@ if [ -f LOCAL.config ]; then
 fi
 
 echo "* Compiler version:"
-9c -v 2>&1 | grep -v 'Configured with:' | grep -i version | sed 's/^/	/'
+9c -v $CCVERSFLAG 2>&1 | grep -v 'Configured with:' | grep -i version | sed 's/^/	/'
 
 cd src
 if $dobuild; then

--- a/bin/9c
+++ b/bin/9c
@@ -103,6 +103,7 @@ usexlc()
 		-qsuppress=1506-224 \
 		-qsuppress=1506-1300 \
 		-qsuppress=1506-342 \
+		-qsuppress=1506-311 \
 	"
 	cflags="$cflags -g -qdbxextra -qfullpath"
 	cflags="$cflags $CC9FLAGS"

--- a/bin/9l
+++ b/bin/9l
@@ -335,6 +335,9 @@ quiet()
 	ignore=$ignore'|text-based stub'
 	# macOS linker is incessant about reoccurring -l9, -lsec, -lthread:
 	ignore=$ignore'|ld: warning: ignoring duplicate libraries:'
+	# ignore duplicate symbols on AIX
+	ignore=$ignore'|0711-224'
+	ignore=$ignore'|0711-345'
 
 	sed 's/.*: In function `[^:]*: *//' "$1" |
 	egrep -v "$ignore"

--- a/src/cmd/fontsrv/freetyperules.sh
+++ b/src/cmd/fontsrv/freetyperules.sh
@@ -6,7 +6,11 @@ if [ "x$1" = "xx11" ]; then
 	else
 		i=$2
 	fi
-	echo 'CFLAGS=$CFLAGS '$i'/freetype2' 
-        echo 'LDFLAGS=$LDFLAGS -lfontconfig -lfreetype -lz'
+	if [ "x`uname`" = "xAIX" ]; then
+		i="-I/opt/freeware/include"
+		l="-L/opt/freeware/lib"
+	fi
+	echo 'CFLAGS=$CFLAGS '$i' '$i'/freetype2'
+        echo 'LDFLAGS=$LDFLAGS '$l' -lfontconfig -lfreetype -lz'
 fi
 

--- a/src/cmd/mkfile
+++ b/src/cmd/mkfile
@@ -5,6 +5,7 @@ TARG=`ls *.[cy] *.lx | egrep -v "\.tab\.c$|^x\." | sed 's/\.[cy]//; s/\.lx//'`
 <$PLAN9/src/mkmany
 
 BUGGERED='CVS|faces|factotum|lp|ip|mailfs|upas|vncv|mnihongo|mpm|index|u9fs|secstore|smugfs|snarfer'
+BUGGERED=${BUGGERED}`[ $(uname) = AIX ] && echo '|rio'`
 DIRS=lex `ls -l |sed -n 's/^d.* //p' |egrep -v "^($BUGGERED)$"|egrep -v '^lex$'` $FONTSRV
 
 <$PLAN9/src/mkdirs

--- a/src/lib9/await.c
+++ b/src/lib9/await.c
@@ -2,6 +2,7 @@
 #include <u.h>
 #include <libc.h>
 
+#include <errno.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -95,8 +96,15 @@ _await(int pid4, char *str, int n, int opt)
 			pid = wait3(&status, opt, &ru);
 		else
 			pid = wait4(pid4, &status, opt, &ru);
-		if(pid <= 0)
+		if(pid <= 0){
+			if(errno == EINTR)
+				continue;
+#ifdef ERESTART
+			if(errno == ERESTART)
+				continue;
+#endif
 			return -1;
+		}
 		u = ru.ru_utime.tv_sec*1000+((ru.ru_utime.tv_usec+500)/1000);
 		s = ru.ru_stime.tv_sec*1000+((ru.ru_stime.tv_usec+500)/1000);
 		if(WIFEXITED(status)){


### PR DESCRIPTION
These commits address several issues on AIX:

* Fix the build on newer versions of AIX
* Clean up the errors displayed by 9c/9l
* Update INSTALL to provide an experience closer to what is offered on other platforms.
* Fix the build of fontsrv on AIX
* Prevent rio from being built on AIX as it is permanently incompatible
* Fix an issue with the post9pservice call which causes some programs to crash on AIX 7.3

Unfortunately, this introduces a requirement to install gawk on AIX, however doing so is fairly straightforward.