### PR TITLE
E as editinacme

### DIFF
--- a/bin/E
+++ b/bin/E
@@ -2,17 +2,26 @@
 
 # run B but then wait for the file to change.
 # great to set as $EDITOR.
-# the notion of a file changing is a little weak.
+# if editing in acme, watch for the moment the window is closed.
+# otherwise the notion of a file changing is a little weak.
 
 stat=`ls -l $1`
 B "$@"
 echo editing "$@"
-while sleep 1
-do
-	nstat=`ls -l $1`
-	if [ "x$stat" != "x$nstat" ]
-	then
-		exit
-	fi
-done
+
+9p read acme/index | grep -q $(realpath $1)
+if [ $? -eq 0 ]; then
+	pat="del $(realpath $1)"
+	9p read acme/log 2> /dev/null |  grep -q "$pat"
+	if [ $? -eq 0 ]; then exit; fi
+else
+	while sleep 1
+	do
+		nstat=`ls -l $1`
+		if [ "x$stat" != "x$nstat" ]
+		then
+			exit
+		fi
+	done
+fi
 

--- a/bin/E
+++ b/bin/E
@@ -5,6 +5,10 @@
 # if editing in acme, watch for the moment the window is closed.
 # otherwise the notion of a file changing is a little weak.
 
+if [ "$1" = "--" ]; then
+	shift
+fi
+
 file=$(echo $1 | cut -d ':' -f 1)
 
 stat=`ls -l $file`

--- a/bin/E
+++ b/bin/E
@@ -5,19 +5,19 @@
 # if editing in acme, watch for the moment the window is closed.
 # otherwise the notion of a file changing is a little weak.
 
-stat=`ls -l $1`
+file=$(echo $1 | sed -E 's/(.*):.*/\1/')
+stat=`ls -l $file`
 B "$@"
 echo editing "$@"
 
-9p read acme/index | grep -q $(realpath $1)
+9p read acme/index | grep -q $(realpath $file)
 if [ $? -eq 0 ]; then
-	pat="del $(realpath $1)"
-	9p read acme/log 2> /dev/null |  grep -q "$pat"
+	9p read acme/log 2> /dev/null |  grep -q "del $(realpath $file)"
 	if [ $? -eq 0 ]; then exit; fi
 else
 	while sleep 1
 	do
-		nstat=`ls -l $1`
+		nstat=`ls -l $file`
 		if [ "x$stat" != "x$nstat" ]
 		then
 			exit

--- a/bin/E
+++ b/bin/E
@@ -12,9 +12,9 @@ B "$@"
 echo editing "$@"
 
 p=$(realpath $file)
-9p read acme/index | grep -q $p
-if [ $? -eq 0 ]; then
-	9p read acme/log 2> /dev/null | grep -q "del $p"
+win=$(9p read acme/index | awk -v p=$p '$0 ~ p {print $1}')
+if [ "$win" -gt 0 ]; then
+	9p read acme/log | sed -n "/$win del/q"
 else
 	while sleep 1
 	do

--- a/bin/E
+++ b/bin/E
@@ -5,15 +5,16 @@
 # if editing in acme, watch for the moment the window is closed.
 # otherwise the notion of a file changing is a little weak.
 
-file=$(echo $1 | sed -E 's/(.*):.*/\1/')
+file=$(echo $1 | cut -d ':' -f 1)
+
 stat=`ls -l $file`
 B "$@"
 echo editing "$@"
 
-9p read acme/index | grep -q $(realpath $file)
+p=$(realpath $file)
+9p read acme/index | grep -q $p
 if [ $? -eq 0 ]; then
-	9p read acme/log 2> /dev/null |  grep -q "del $(realpath $file)"
-	if [ $? -eq 0 ]; then exit; fi
+	9p read acme/log 2> /dev/null | grep -q "del $p"
 else
 	while sleep 1
 	do

--- a/man/man1/9p.1
+++ b/man/man1/9p.1
@@ -7,6 +7,9 @@
 .I options
 ]
 .B read
+[
+.B -f
+]
 .I path
 .br
 .B 9p
@@ -79,13 +82,21 @@ The first argument is a command, one of:
 .TP
 .B read
 print the contents of
-.I path 
-to standard output
+.I path
+to standard output ;
+the
+.B -f
+option causes
+.I read
+to follow the file, exactly like the
+.B -f
+option of
+.IR tail(1)
 .TP
 .B write
 write data on standard input to
 .IR path ;
-the 
+the
 .B -l
 option causes
 .I write
@@ -94,7 +105,7 @@ to write one line at a time
 .BR readfd ", " writefd
 like
 .B read
-and 
+and
 .B write
 but use
 .IR openfd (9p)
@@ -107,7 +118,7 @@ the implementation of
 .B stat
 execute
 .I stat (9p)
-on 
+on
 .I path
 and print the result
 .TP


### PR DESCRIPTION
In the expected case where the files ends up being edited in acme, do as [editinacme](https://github.com/9fans/go/blob/v0.0.7/acme/editinacme/main.go) does: when the window of the file is closed it means we're done. No need for an extra binary in another repository. The old logic is kept as a backup.

In addition, allow line numbers to be specified in the input (as in `E file:13`) and still work with both logics.