### PR TITLE
Provide follow option to 9p

### DIFF
--- a/man/man1/9p.1
+++ b/man/man1/9p.1
@@ -7,6 +7,9 @@
 .I options
 ]
 .B read
+[
+.B -f
+]
 .I path
 .br
 .B 9p
@@ -79,13 +82,21 @@ The first argument is a command, one of:
 .TP
 .B read
 print the contents of
-.I path 
-to standard output
+.I path
+to standard output ;
+the
+.B -f
+option causes
+.I read
+to follow the file, exactly like the
+.B -f
+option of
+.IR tail(1)
 .TP
 .B write
 write data on standard input to
 .IR path ;
-the 
+the
 .B -l
 option causes
 .I write
@@ -94,7 +105,7 @@ to write one line at a time
 .BR readfd ", " writefd
 like
 .B read
-and 
+and
 .B write
 but use
 .IR openfd (9p)
@@ -107,7 +118,7 @@ the implementation of
 .B stat
 execute
 .I stat (9p)
-on 
+on
 .I path
 and print the result
 .TP

--- a/src/cmd/9p.c
+++ b/src/cmd/9p.c
@@ -15,7 +15,7 @@ usage(void)
 {
 	fprint(2, "usage: 9p [-n] [-a address] [-A aname] cmd args...\n");
 	fprint(2, "possible cmds:\n");
-	fprint(2, "	read name\n");
+	fprint(2, "	read [-f] name\n");
 	fprint(2, "	readfd name\n");
 	fprint(2, "	write [-l] name\n");
 	fprint(2, "	writefd name\n");
@@ -171,8 +171,12 @@ xread(int argc, char **argv)
 	char buf[4096];
 	int n;
 	CFid *fid;
+	int follow = 0;
 
 	ARGBEGIN{
+	case 'f':
+		follow = 1;
+		break;
 	default:
 		usage();
 	}ARGEND
@@ -182,9 +186,14 @@ xread(int argc, char **argv)
 
 	fid = xopen(argv[0], OREAD);
 	proccreate(checkout, nil, 32768);
-	while((n = fsread(fid, buf, sizeof buf)) > 0)
+	while((n = fsread(fid, buf, sizeof buf)) >= 0) {
+		if (n == 0 && !follow)
+			break;
 		if(write(1, buf, n) < 0)
 			sysfatal("write error: %r");
+		if (n == 0 && follow)
+			sleep(1000);
+	}
 	fsclose(fid);
 	if(n < 0)
 		sysfatal("read error: %r");


### PR DESCRIPTION
This is like `tail -f` but for `9p read`

Requires #708 