### PR TITLE
Fix #716: Will not build on gcc 15

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -18,7 +18,6 @@ usegcc()
 		-Wno-stringop-truncation \
 		-Wno-stringop-overflow \
 		-Wno-format-truncation \
-		-Wno-deprecated-pragma \
 		-Wno-unused-but-set-variable \
 		-Wno-deprecated-declarations \
 		-fno-omit-frame-pointer \

--- a/bin/9c
+++ b/bin/9c
@@ -23,6 +23,7 @@ usegcc()
 		-fno-omit-frame-pointer \
 		-fsigned-char \
 		-fcommon \
+		-std=c17 \
 	"
 	# want to put -fno-optimize-sibling-calls here but
 	# that option only works with gcc3+ it seems

--- a/bin/9c
+++ b/bin/9c
@@ -23,7 +23,7 @@ usegcc()
 		-fno-omit-frame-pointer \
 		-fsigned-char \
 		-fcommon \
-		-std=c17 \
+		-std=c11 \
 	"
 	# want to put -fno-optimize-sibling-calls here but
 	# that option only works with gcc3+ it seems

--- a/include/u.h
+++ b/include/u.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 #define _LARGEFILE64_SOURCE 1
 #define _FILE_OFFSET_BITS 64
-
+#define __USE_POSIX 1 //needed for sigjmp_buf in glibc setjmp.h
 #include <inttypes.h>
 
 #include <unistd.h>


### PR DESCRIPTION
add -std=c17 to fix build failures on gcc 15 with c23 by default

for u.h i had to `#define __USE_POSIX 1` because `sigjmp_buf` is defined under an `#ifdef __USE_POSIX` in glibc, see https://github.com/bminor/glibc/blob/3473526758532d7356be80c7950e476e235b5fb2/setjmp/setjmp.h#L70