### PR TITLE
B: Don't munge $DISPLAY in sam's fifo path

### DIFF
--- a/bin/B
+++ b/bin/B
@@ -23,10 +23,6 @@ if [ "x$DISPLAY" = "x" ]
 then
 	sam="/tmp/.sam.$USER"
 else
-	if [ "$DISPLAY" = ":0" ]
-	then
-		DISPLAY=:0.0
-	fi
 	sam="/tmp/.sam.$USER.$DISPLAY"
 fi
 


### PR DESCRIPTION
B first attempts to communicate with sam over its named pipe before falling back to the plumber if that named pipe cannot be found. sam's named pipe is placed at a known location which is where B attempts to find it.

This location is defined in src/cmd/samterm/plan9.c:extstart():

        user = getenv("USER");
        if(user == nil)
                return;
        disp = getenv("DISPLAY");
        if(disp){
                exname = smprint("/tmp/.sam.%s.%s", user, disp);
                free(disp);
        }
        else
                exname = smprint("/tmp/.sam.%s", user);

Observe that the path is determined by $USER and $DISPLAY.

However, when B is constructing the path of sam's fifo, if it finds $DISPLAY is ":0", it overrides $DISPLAY to be ":0.0".

This means that B uses a different path for the fifo then the location where it was actually created by sam. As a result B cannot find sam's fifo and B falls back to using the plumber for communication. This is an issue if the plumber has not been started:

	plumb: can't open plumb file: dial unix!/tmp/ns.jpn.:0/plumb: connect /tmp/ns.jpn.:0/plumb: No such file or directory

Note that previously B did not perform this munging - it was added in commit 669250d159e9 ("Various fixes.") with the description:

	"B - fixed usage, DISPLAY :0 vs :0.0"

This does not work in the general case so return to using $DISPLAY directly.

Tested on Debian 12 using KDE w/ x11: B is able to communicate with sam even if the plumber is not running.

Signed-off-by: Jordan Niethe <jniethe5@gmail.com>

---

It is not clear to me why the :0 vs :0.0 change was required previously. Is this still necessary? We could have B look for both :0 and :0.0 if there are some systems / configurations where this is needed..