### PR TITLE
Fix mouse cursor stack if new window created after colgrow right window

### DIFF
--- a/src/cmd/acme/cols.c
+++ b/src/cmd/acme/cols.c
@@ -469,7 +469,6 @@ colgrow(Column *c, Window *w, int but)
 	free(nl);
 	free(ny);
 	c->safe = TRUE;
-	winmousebut(w);
 }
 
 void


### PR DESCRIPTION
In the forum user [kaldeon](https://www.linux.org.ru/people/kaldeon/profile) show me a bug https://www.linux.org.ru/forum/talks/17709316?cid=18077919

 * video with bug http://0x0.st/Kb4J.30am.mp4  created by user kaldeon

Im expect code and found problem. If for new window `coladd` no have place in colomn, for previos bottom window do `colgrow` for make more space. Problem, after `colgrow`  called `winmousebut` and  one more times **override** mouse position to growed window **before** save mouse position `savemouse` for call `restoremouse` in future and if we close new window, mouse cursor dont jump back to previos window, and stay on last colomn growed window. Just **no need** every time change mouse pose value, to autogrow window. Moreover in this


https://github.com/9fans/plan9port/blob/bafcdddd31811cb9b13f2a984b291446de04a20b/src/cmd/acme/cols.c#L506-L509

This is what is done, which confirms that call  `winmousebut` inside  `colgrow` is a bug

 * video without bug https://0x0.st/Kc-c.ogv created by me 

-----

Im not user plan9port and acme, and use acme first time, I've double-checked many times to see if this change changes behavior anywhere, but as far as I could examine the code, and as far as I could test it all in the editor, there are no regressions.

-----

P.S. Sorry for my English, I wrote half of it myself and just translated some of the text into English :D