### PR TITLE
man: remove -s from usage message

### DIFF
--- a/bin/man
+++ b/bin/man
@@ -68,7 +68,7 @@ fn dohtml {
 #
 # parse flags and sections
 #
-fn usage { echo 'Usage: man [-hnpPtw] [-s sec] [0-9] [0-9] ... [--] name1 name2 ...' >[1=2] }
+fn usage { echo 'Usage: man [-hnpPtw] [0-9] [0-9] ... [--] name1 name2 ...' >[1=2] }
 cmd=donroff
 sec=()
 S=$PLAN9/man


### PR DESCRIPTION
As far as I can tell, the -s advertised in the usage message has never been implemented. It'd be trivial to add (put "case -s ; sec=($sec $2) ; shift 2" to the switch on line 85) , but isn't in the manual, and seems redundant with the existing way of specifying sections. Make the usage message match the rest of the code and man page.