### PR TITLE
tbl: make unrecognized column mods less lethal

### DIFF
--- a/src/cmd/tbl/t.h
+++ b/src/cmd/tbl/t.h
@@ -135,6 +135,7 @@ void choochar(void);			/*tc.c*/
 int point(char *);
 
 void error(char *);			/*te.c*/
+void warn(char *);
 char *gets1(char *, int);
 void un1getc(int);
 int get1char(void);

--- a/src/cmd/tbl/t4.c
+++ b/src/cmd/tbl/t4.c
@@ -46,9 +46,15 @@ readspec(void)
 		switch (c) {
 		default:
 			if (c != tab) {
-				char buf[64];
-				sprint(buf, "bad table specification character %c", c);
-				error(buf);
+				char buf[64], q = '\'';
+				if (c == '\'')
+					q = '\"';
+				if (!sawchar) {
+					snprint(buf, sizeof(buf), "bad table specification character %c", c);
+					error(buf);
+				}
+				snprint(buf, sizeof(buf), "unrecognized column modifier character %c%c%c", q, c, q);
+				warn(buf);
 			}
 		case ' ': /* note this is also case tab */
 			continue;

--- a/src/cmd/tbl/te.c
+++ b/src/cmd/tbl/te.c
@@ -10,6 +10,13 @@ error(char *s)
 }
 
 
+void
+warn(char *s)
+{
+	fprint(2, "\n%s:%d: warning: %s\n", ifile, iline, s);
+}
+
+
 char	*
 gets1(char *s, int size)
 {


### PR DESCRIPTION
src/cmd/tbl: add `warn()` function
    
Up to this point, tbl has had no nonfatal diagnostics.  A forthcoming
change requires one.

src/cmd/tbl/t4.c: be robust to extensions

DWB 3.3 tbl and GNU tbl support an 'x' column modifier.  (Heirloom
Doctools tbl and mandoc(1) also support it.)  Plan 9 tbl aborts
processing of the entire input document if it encounters this characater
in a table description.

That's overkill; it's safe to ignore that modifier if it really is a
_modifier_, and the column descriptor has a classifier already, like 'L'
or 'N'.  The `sawchar` local variable, of Boolean sense, in `readspec()`
appears to indicate that fact.

Many man pages in the wild, such as those of ncurses, use the 'x'
modifier; while this change doesn't make Plan 9 tbl implement the
extension, it does help Plan 9 render such pages on a best-effort basis.
Extending this toleration also permits man page authors to wangle a
portable hack into their pages by specifying an explicit width followed
by the 'x' modifier that implementations supporting it will honor
(example: 'Lw(22n)x').

The GNU tbl(1) man page says:

>    Column modifiers
>      Any number of modifiers can follow a column classifier.  Modifier
>      arguments, where accepted, are case‐sensitive.  If a given modifier
>      is applied to a classifier more than once, or if conflicting
>      modifiers are applied, only the last occurrence has effect.  The
>      modifier x is mutually exclusive with e and w, but e is not
>      mutually exclusive with w; if these are used in combination,
>      x unsets both e and w, while either e or w overrides x.

Heirloom Doctools and mandoc(1) behave compatibly with the foregoing
description.

Before:
```
$ printf '.TS\nLx.\ntable cell\n.TE\n' | 9 tbl | 9 nroff -man | col | cat -s

Input:2: bad table specification character x
tbl quits
```

After:
```
$ printf '.TS\nLx.\ntable cell\n.TE\n' | 9 tbl | 9 nroff -man | col | cat -s

Input:2: warning: unrecognized column modifier character 'x'
     table cell

$ printf '.TS\nx.\ntable cell\n.TE\n' | 9 tbl | 9 nroff -man | col | cat -s

Input:2: bad table specification character x
tbl quits

$ printf '.TS\ntab(@);\nL Lx.\ncell one@cell two\n.TE\n' | 9 tbl | 9 nroff -man | col | cat -s

Input:3: warning: unrecognized column modifier character 'x'
     cell one   cell two

$ printf '.TS\ntab(@);\nL,x.\ncell one@cell two\n.TE\n' | 9 tbl | 9 nroff -man | col | cat -s

Input:3: bad table specification character x
tbl quits

```

I confess to using my own terminology rather than Mike Lesk's.  See
<https://man7.org/linux/man-pages/man1/tbl.1.html>.