### PR TITLE
fix: consider FocusIn when X11 devdraw repaints; remove a delaying check

### DIFF
--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -385,15 +385,15 @@ runxevent(XEvent *xev)
 	case MapNotify:
 	case FocusIn:    
 	case Expose:     /* Handle standard Expose here too for consistency */
-			/* * Force a copy from backing store (screenpm) to the window.
-			 * We removed the (screenpm == nextscreenpm) check because 
-			 * a slightly "tearing" frame is better than a blank one.
+			/*
+			 * Force a copy from backing store (screenpm) to the window.
 			 */
 			if(w->screenpm){
 				XCopyArea(_x.display, w->screenpm, w->drawable, _x.gccopy,
 					0, 0, Dx(w->screenr), Dy(w->screenr), 0, 0);
 			}
-			/* * If this was a real Expose event, we still let standard handling
+			/*
+			 * If this was a real Expose event, we still let standard handling
 			 * run just in case, though the CopyArea above likely did the job.
 			 */
 			if(xev->type == Expose)


### PR DESCRIPTION
This improves on commit b3741e6, by repainting also when FocusIn occurs, and also by now drawing the current image once again in case devdraw happens to be busy working on the next. The problems with blank windows these improvements solve became apparent under use of one or more instances of the X server intensive winwatch, for example one per virtual desktop. (Only one instance would need to run if a rio window could be made to stick.)