### PR TITLE
win: fix spaces in Acme window tag

### DIFF
--- a/src/cmd/9term/win.c
+++ b/src/cmd/9term/win.c
@@ -182,7 +182,7 @@ threadmain(int argc, char **argv)
 	putenv("winid", buf);
 	sprint(buf, "%d/tag", id);
 	fd = fsopenfd(fs, buf, OWRITE|OCEXEC);
-	write(fd, " Send", 1+4);
+	write(fd, "Send ", 4+1);
 	close(fd);
 	sprint(buf, "%d/event", id);
 	eventfd = fsopen(fs, buf, ORDWR|OCEXEC);


### PR DESCRIPTION
Acme adds a space after Look at the end of window tags.  Therefore, the space before Send is not needed.  The space after Send is for consistency and convenience.