### PR TITLE
fontsrv: improve rendering of slanted fonts (italics) on macOS

### DIFF
--- a/src/cmd/fontsrv/mac.c
+++ b/src/cmd/fontsrv/mac.c
@@ -297,6 +297,7 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 	x = 0;
 	for(i=lo; i<=hi; i++, fc++) {
 		char buf[20];
+		int iwidth;
 		CFStringRef str;
 		CFDictionaryRef attrs;
 		CFAttributedStringRef attrString;
@@ -321,6 +322,7 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 		line = CTLineCreateWithAttributedString(attrString);
 		CGContextSetTextPosition(ctxt, 0, y0);
 		r = CTLineGetImageBounds(line, ctxt);
+		iwidth = ceil(r.size.width+r.origin.x);
 		memfillcolor(mc, DWhite);
 		CTLineDraw(line, ctxt);
 		CFRelease(line);
@@ -342,10 +344,10 @@ mksubfont(XFont *f, char *name, int lo, int hi, int size, int antialias)
 		}
 
 		meminvert(mc);
-		memimagedraw(m, Rect(x, 0, x + p1.x, y), mc, ZP, memopaque, ZP, S);
+		memimagedraw(m, Rect(x, 0, x + iwidth, y), mc, ZP, memopaque, ZP, S);
 		fc->width = p1.x;
 		fc->left = 0;
-		x += p1.x;
+		x += iwidth;
 	}
 	fc->x = x;
 


### PR DESCRIPTION
Improves renderings of Italic fonts, e.g. the [Go font](https://go.dev/blog/go-fonts) (#765).

* Before:

<img width="506" height="343" alt="Screenshot 2026-04-13 at 21 54 34" src="https://github.com/user-attachments/assets/5132692c-3ad0-4e75-a0f1-72052cf5e0c7" />

* After:

<img width="506" height="343" alt="Screenshot 2026-04-13 at 22 11 55" src="https://github.com/user-attachments/assets/155f24d8-6a49-4f93-a386-261a507a2d59" />

For comparison, macOS's own rendering (TextEdit) is shown below:

<img width="520" height="343" alt="Screenshot 2026-04-13 at 22 29 55" src="https://github.com/user-attachments/assets/6a3c6236-72ce-4ddb-86bd-ec9e9b4df97d" />

---
The nature of the fix is to include the actual rendering width into the character size maths, while retaining the original logic for keeping the position advancements.

An inspection of the sub font with [tweak(1)](http://9p.io/magic/man2html?man=tweak&sect=1) shows larger _iwidth_ while retaining _width_ values.

* before:
<img width="1392" height="832" alt="Image" src="https://github.com/user-attachments/assets/36511eb8-349c-47d4-8cdc-6552ddbae75a" />

* after:
<img width="1392" height="832" alt="Screenshot 2026-04-13 at 22 34 18" src="https://github.com/user-attachments/assets/5d11d964-219c-4171-982c-5dd8fb5a95a9" />


The remaining glitches at the end of lines, as well as the clipping of the characters upon selection, are due to assumptions in _frselect_ and the direct uses of _frdrawsel_ of _libframe_ in acme, sam and other clients; the assumptions being that the adjacent characters never overlap. Being much, much trickier to address, those fall outside of the scope of the proposed fix.
