### PR TITLE
fontsrv: improve rendering of slanted fonts (italics) on X11

### DIFF
--- a/src/cmd/fontsrv/x11.c
+++ b/src/cmd/fontsrv/x11.c
@@ -199,13 +199,13 @@ mksubfont(XFont *xf, char *name, int lo, int hi, int size, int antialias)
 		for(r=0; r < bitmap->rows; r++)
 			memmove(base + r*mc->width*sizeof(u32int), bitmap->buffer + r*bitmap->pitch, bitmap->pitch);
 
-		memimagedraw(m, Rect(x, 0, x + advance, y), mc,
-			Pt(-face->glyph->bitmap_left, -(y - y0 - face->glyph->bitmap_top)),
+		memimagedraw(m, Rect(x, 0, x + bitmap->width, y), mc,
+			Pt(0, -(y - y0 - face->glyph->bitmap_top)),
 			memopaque, ZP, S);
 
 		fc->width = advance;
-		fc->left = 0;
-		x += advance;
+		fc->left = face->glyph->bitmap_left;
+		x += bitmap->width;
 
 #ifdef DEBUG_FT_BITMAP
 		for(r=0; r < bitmap->rows; r++) {


### PR DESCRIPTION
Improves renderings of Italic fonts, e.g. _URWBookman-DemiItalic_.

Improve renderings of Italic fonts, e.g. the [Go font](https://go.dev/blog/go-fonts).

Before and after, as presented with [tweak(1)](http://9p.io/magic/man2html?man=tweak&sect=1):

<img width="1362" height="870" alt="20260422_14h26m58s_grim" src="https://github.com/user-attachments/assets/1a71ffb5-3736-4362-b5ac-6c4b0cc92e33" />


As before, the nature of the fix is to include the actual rendering width into the character size math, while retaining the original logic of tracking the position advancements: note the larger _iwidth_ values, with the _width_ and _left_ values used for the tracking.

This does not yet address the remaining visual artefacts produced by the programs which make certain assumptions in _frselect_ and the direct uses of _frdrawsel_ of _libframe_ in acme, sam and other clients; the assumptions being that the adjacent characters never overlap. Being much, much trickier to address, those fall outside of the scope of the proposed fix.

In #766 a similar fix was made to the macOS version of the program, and yrk-lab/fontsrv#4 is equivalent to the proposed fix.

Fixes #765 for X11 systems (Linux).

Tested on Raspbian (Debian) Trixie.
