### PR TITLE
fix INSTALL when rc-related environment vars are set

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -141,6 +141,13 @@ fi
 echo "* Compiler version:"
 9c -v 2>&1 | grep -v 'Configured with:' | grep -i version | sed 's/^/	/'
 
+# The user might have set the following environment variables
+# but they'll cause the plan9port build to fail if set because
+# it assumes sh semantics in mkfiles, so ensure they are
+# unset.
+unset FORCERCFORMK
+unset MKSHELL
+
 cd src
 if $dobuild; then
 	echo "* Building mk..."


### PR DESCRIPTION
If the variables FORCERCFORMK or MKSHELL
are set in the user's environment, the Plan 9 build will fail, so avoid that by unsetting them in the INSTALL script.

Patch courtesy of Jeff Sickel
