### PR TITLE
INSTALL: set $NPROC for linux

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -67,6 +67,7 @@ DragonFly|*BSD)
 	echo "CFLAGS='-pthread'" >> $PLAN9/config
 	;;
 *Linux*)
+	export NPROC="$(nproc)"
 	egrep='grep -E'
 	;;
 esac


### PR DESCRIPTION
Speed up compile time significantly.

Before: ./INSTALL  127.66s user 46.23s system 107% cpu 2:41.27 total
After : ./INSTALL  233.35s user 76.86s system 416% cpu 1:14.56 total