### PR TITLE
factotum: do not guess the secstore address

### DIFF
--- a/src/cmd/auth/factotum/secstore.c
+++ b/src/cmd/auth/factotum/secstore.c
@@ -24,12 +24,12 @@ secdial(void)
 	char *p;
 
 	p = secstore;
-	if(p == nil)	  /* else use the authserver */
+	if(p == nil)
 		p = getenv("secstore");
-	if(p == nil)
-		p = getenv("auth");
-	if(p == nil)
-		p = "secstore";
+	if(p == nil){
+		werrstr("no secstore");
+		return -1;
+	}
 
 	return dial(netmkaddr(p, "net", "secstore"), 0, 0, 0);
 }


### PR DESCRIPTION
On Plan 9, factotum uses ndb to find whether the authentication domain has a secstore. There is no ndb here, so secdial guessed the address by dialing $auth or the host "secstore".

This blocks factotum's startup, and thus its 9P service, when there is no secstore: the auth server is not a secstore and stalls the read, and resolving "secstore" can hang.

Only dial a secstore explicitly set through $secstore.