### PR TITLE
factotum: do not fail the rpc read with a reply pending

### DIFF
--- a/src/cmd/auth/factotum/fs.c
+++ b/src/cmd/auth/factotum/fs.c
@@ -330,6 +330,16 @@ fsread(Req *r)
 	case Qrpc:
 		c = r->fid->aux;
 		if(c->rpc.op == RpcUnknown){
+			/*
+			 * The conv may have produced its reply and reset the op
+			 * (rpcrespond) before this read arrived: deliver the
+			 * buffered reply instead of failing with "no rpc pending".
+			 */
+			if(c->nreply && c->req == nil){
+				c->req = r;
+				(*c->kickreply)(c);
+				break;
+			}
 			respond(r, "no rpc pending");
 			break;
 		}


### PR DESCRIPTION
A conversation produces a reply with rpcrespond, which buffers it and resets the rpc op to RpcUnknown.

The conversation can produce the reply before the
matching read of /mnt/factotum/rpc arrives. The read then finds the op reset and responds "no rpc pending", even though a reply is buffered.

This race is timing dependent and rarely seen, but some clients trigger it often, breaking p9sk1
authentication through auth_proxy.

This change delivers the buffered reply in that case, instead of failing the read.