### PR TITLE
libdraw: bound the _twiddlecompressed loop to avoid an out-of-bounds write

### DIFF
--- a/src/libdraw/computil.c
+++ b/src/libdraw/computil.c
@@ -18,7 +18,7 @@ _twiddlecompressed(uchar *buf, int n)
 		c = *buf++;
 		if(c >= 128){
 			k = c-128+1;
-			for(j=0; j<k; j++, buf++)
+			for(j=0; j<k && buf<ebuf; j++, buf++)
 				*buf ^= 0xFF;
 		}else
 			buf++;


### PR DESCRIPTION
_twiddlecompressed inverts the bytes of an old-format image(6) block. For a literal run it reads a length byte and flips that many bytes, but never checks the count against the end of the block. A truncated or crafted image whose final literal claims more bytes than remain makes the loop write past the end of the buffer, corrupting the adjacent heap and crashing the reader.

Stop the inner loop at the end of the buffer.

Thanks to Arusekk for the report and the fix.