### PR TITLE
lib9: avoid a buffer overflow formatting a stat in fcallfmt

### DIFF
--- a/src/lib9/fcallfmt.c
+++ b/src/lib9/fcallfmt.c
@@ -15,7 +15,7 @@ fcallfmt(Fmt *fmt)
 	int fid, type, tag, i;
 	char buf[512], tmp[200];
 	char *p, *e;
-	Dir *d;
+	Dir d;
 	Qid *q;
 
 	e = buf+sizeof(buf);
@@ -124,24 +124,20 @@ fcallfmt(Fmt *fmt)
 		break;
 	case Rstat:
 		p = seprint(buf, e, "Rstat tag %ud ", tag);
-		if(f->stat == nil || f->nstat > sizeof tmp)
+		if(f->stat == nil || f->nstat > sizeof tmp || convM2D(f->stat, f->nstat, &d, tmp) == 0)
 			seprint(p, e, " stat(%d bytes)", f->nstat);
 		else{
-			d = (Dir*)tmp;
-			convM2D(f->stat, f->nstat, d, (char*)(d+1));
 			seprint(p, e, " stat ");
-			fdirconv(p+6, e, d);
+			fdirconv(p+6, e, &d);
 		}
 		break;
 	case Twstat:	/* 126 */
 		p = seprint(buf, e, "Twstat tag %ud fid %ud", tag, fid);
-		if(f->stat == nil || f->nstat > sizeof tmp)
+		if(f->stat == nil || f->nstat > sizeof tmp || convM2D(f->stat, f->nstat, &d, tmp) == 0)
 			seprint(p, e, " stat(%d bytes)", f->nstat);
 		else{
-			d = (Dir*)tmp;
-			convM2D(f->stat, f->nstat, d, (char*)(d+1));
 			seprint(p, e, " stat ");
-			fdirconv(p+6, e, d);
+			fdirconv(p+6, e, &d);
 		}
 		break;
 	case Rwstat:


### PR DESCRIPTION
The Rstat and Twstat cases decoded the incoming stat message by casting the 200-byte scratch buffer tmp to a Dir and asking convM2D to store the variable-length strings at (char*)(d+1), which leaves fewer than 200 bytes for them. A stat with long enough name, uid, gid and muid strings therefore overflows tmp on the stack. The cast also assumes tmp is aligned for a Dir, which need not hold on machines that require aligned access, and the convM2D return value was ignored, so a malformed stat left the Dir uninitialized and fdirconv then formatted garbage.

Decode into a real Dir on the stack, which is properly aligned, and let convM2D use all of tmp for the strings. Check its result and fall back to printing the byte count when the stat cannot be decoded.

Thanks to Arusekk for the report and the fix.