### PR TITLE
libmemdraw: zero the cloadmemimage buffer to avoid disclosing uninitialized memory

### DIFF
--- a/src/libmemdraw/cload.c
+++ b/src/libmemdraw/cload.c
@@ -14,6 +14,7 @@ _cloadmemimage(Memimage *i, Rectangle r, uchar *data, int ndata)
 	bpl = bytesperline(r, i->depth);
 	u = data;
 	eu = data+ndata;
+	memset(mem, 0, sizeof mem);
 	memp = mem;
 	emem = mem+NMEM;
 	y = r.min.y;


### PR DESCRIPTION
_cloadmemimage decodes the image(6) compression using a sliding window, mem, that is never initialized. When a repeat command appears before enough literal data has been written, or otherwise reaches back past the start of the window, the decoder copies uninitialized bytes into the decoded image. Any code that decodes a compressed image can then read them back and recover stale stack memory, including pointers useful for defeating address space randomization.

Zero the window before decoding. The original Lempel-Ziv algorithm assumes an all-zero window, so reads that reach past the written data return zeros instead of stack garbage. The bug dates back to the first release of the image compression code.

Thanks to Arusekk for the report and the fix.