### PR TITLE
devdraw: use window position from X resources only if present

### DIFF
--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -682,7 +682,7 @@ xattach(Client *client, char *label, char *winsize)
 			normalhint.width = width;
 			normalhint.height = height;
 		}
-		if((mask & WidthValue) && (mask & HeightValue)){
+		if((mask & XValue) || (mask & YValue)){
 			normalhint.flags |= USPosition;
 			normalhint.x = x;
 			normalhint.y = y;


### PR DESCRIPTION
Before this change, absent both x and y values in window geometry was treated as if user specified +0+0.  For example, the following command caused Sam window to be placed in the upper-left corner, rather than at a position chosen by window manager:

    echo 'sam.geometry: 1200x800' | xrdb -merge