### PR TITLE
devdraw: on X11 set dpi even when the window size is given

### DIFF
--- a/man/man1/devdraw.1
+++ b/man/man1/devdraw.1
@@ -68,6 +68,28 @@ there is no way to type
 variants,
 so there is no access to keyboard shortcuts for
 undo, redo, cut, and paste.
+.PP
+.I Devdraw
+scales window borders, scrollbars and fonts to the resolution of the
+display.  On X it looks for that resolution first in the
+.B Xft.dpi
+X resource, then in
+.BR $GDK_SCALE ,
+and last in the physical screen size reported by the server.
+None of the three is dependable under XWayland, which gives every
+output a zero physical size and where nothing sets
+.B Xft.dpi
+unless a desktop environment does it; set
+.B $DEVDRAWDPI
+to say so explicitly.
+.SH ENVIRONMENT
+.TP
+.B DEVDRAWDPI
+Resolution of the display in dots per inch, overriding whatever
+.I devdraw
+would otherwise work out for itself.
+100 suits an ordinary display and 225 a 2x one.
+Values outside the range 50 to 600 are ignored.
 .SH SOURCE
 .B \*9/src/cmd/devdraw
 .SH "SEE ALSO

--- a/src/cmd/devdraw/devdraw.h
+++ b/src/cmd/devdraw/devdraw.h
@@ -2,6 +2,13 @@
 #define NHASH (1<<5)
 #define HASHMASK (NHASH-1)
 
+enum
+{
+	Dpidefault	= 100,	/* used when the display's resolution is unknown */
+	Dpimin		= 50,	/* detected values outside this range are not believed */
+	Dpimax		= 600
+};
+
 typedef struct Kbdbuf Kbdbuf;
 typedef struct Mousebuf Mousebuf;
 typedef struct Tagbuf Tagbuf;
@@ -229,6 +236,7 @@ int draw_datawrite(Client*, void*, int);
 void draw_initdisplaymemimage(Client*, Memimage*);
 
 // utility routines
+int dpioverride(void);
 int latin1(Rune*, int);
 int mouseswap(int);
 int parsewinsize(char*, Rectangle*, int*);

--- a/src/cmd/devdraw/srv.c
+++ b/src/cmd/devdraw/srv.c
@@ -34,6 +34,40 @@ usage(void)
 	threadexitsall("usage");
 }
 
+/*
+ * $DEVDRAWDPI overrides the display resolution reported to clients,
+ * or is 0 when unset.  It exists because the window system cannot
+ * always be asked: XWayland gives every output a zero physical size,
+ * and nothing sets Xft.dpi unless a desktop environment does it.
+ */
+int
+dpioverride(void)
+{
+	static int dpi = -1;
+	char *p;
+
+	if(dpi < 0){
+		dpi = 0;
+		if((p = getenv("DEVDRAWDPI")) != nil){
+			dpi = atoi(p);
+			if(dpi < Dpimin || dpi > Dpimax)
+				dpi = 0;
+			free(p);
+		}
+	}
+	return dpi;
+}
+
+static int
+initialdpi(void)
+{
+	int dpi;
+
+	if((dpi = dpioverride()) != 0)
+		return dpi;
+	return Dpidefault;
+}
+
 void
 threadmain(int argc, char **argv)
 {
@@ -65,7 +99,7 @@ threadmain(int argc, char **argv)
 			fprint(2, "initdraw: allocating client0: out of memory");
 			abort();
 		}
-		client0->displaydpi = 100;
+		client0->displaydpi = initialdpi();
 		client0->rfd = 3;
 		client0->wfd = 4;
 
@@ -129,7 +163,7 @@ listenproc(void *v)
 			fprint(2, "initdraw: allocating client0: out of memory");
 			abort();
 		}
-		c->displaydpi = 100;
+		c->displaydpi = initialdpi();
 		c->rfd = fd;
 		c->wfd = fd;
 		proccreate(serveproc, c, 0);

--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -545,6 +545,80 @@ runxevent(XEvent *xev)
 }
 
 
+/*
+ * Build the resource database from the screen and display resource
+ * strings, falling back to ~/.Xdefaults if the server has none.
+ * Thanks to Peter Canning.
+ */
+static XrmDatabase
+xresources(XScreen *xscreen)
+{
+	char *screen_resources, *display_resources, *home, *file;
+	XrmDatabase database;
+
+	database = XrmGetDatabase(_x.display);
+	screen_resources = XScreenResourceString(xscreen);
+	if(screen_resources != nil){
+		XrmCombineDatabase(XrmGetStringDatabase(screen_resources), &database, False);
+		XFree(screen_resources);
+	}
+
+	display_resources = XResourceManagerString(_x.display);
+	if(display_resources == nil){
+		home = getenv("HOME");
+		if(home!=nil && (file=smprint("%s/.Xdefaults", home)) != nil){
+			XrmCombineFileDatabase(file, &database, False);
+			free(file);
+		}
+		free(home);
+	}else
+		XrmCombineDatabase(XrmGetStringDatabase(display_resources), &database, False);
+
+	return database;
+}
+
+/*
+ * X cannot be asked for the display's resolution directly.
+ * XWayland reports a zero physical size for every output, and the core
+ * screen dimensions span all monitors at once, so on a multi-head
+ * display they describe no real screen.  Prefer whatever the user or
+ * the desktop configured, and only measure the screen as a last resort,
+ * when the result looks believable.
+ */
+static int
+xdpi(XScreen *xscreen, XrmDatabase database)
+{
+	char *e, *type;
+	int dpi, mm;
+	XrmValue v;
+
+	if((dpi = dpioverride()) != 0)
+		return dpi;
+
+	if(XrmGetResource(database, "Xft.dpi", "String", &type, &v) == True && v.addr != nil){
+		dpi = atoi(v.addr);
+		if(dpi >= Dpimin && dpi <= Dpimax)
+			return dpi;
+	}
+
+	/* what GTK and Qt clients fall back to when Xft.dpi is unset */
+	if((e = getenv("GDK_SCALE")) != nil){
+		dpi = atoi(e) * 96;
+		free(e);
+		if(dpi >= Dpimin && dpi <= Dpimax)
+			return dpi;
+	}
+
+	mm = WidthMMOfScreen(xscreen);
+	if(mm > 0){
+		dpi = (WidthOfScreen(xscreen)*254 + mm*5) / (mm*10);
+		if(dpi >= Dpimin && dpi <= Dpimax)
+			return dpi;
+	}
+
+	return Dpidefault;
+}
+
 static Memimage*
 xattach(Client *client, char *label, char *winsize)
 {
@@ -553,6 +627,7 @@ xattach(Client *client, char *label, char *winsize)
 	Rectangle r;
 	XClassHint classhint;
 	XDrawable pmid;
+	XrmDatabase database;
 	XScreen *xscreen;
 	XSetWindowAttributes attr;
 	XSizeHints normalhint;
@@ -563,9 +638,11 @@ xattach(Client *client, char *label, char *winsize)
 	Atom atoms[2];
 	Xwin *w;
 
-	USED(client);
 	xscreen = DefaultScreenOfDisplay(_x.display);
 	xrootwin = DefaultRootWindow(_x.display);
+
+	database = xresources(xscreen);
+	client->displaydpi = xdpi(xscreen, database);
 
 	/*
 	 * We get to choose the initial rectangle size.
@@ -579,41 +656,12 @@ xattach(Client *client, char *label, char *winsize)
 		if(parsewinsize(winsize, &r, &havemin) < 0)
 			sysfatal("%r");
 	}else{
-		/*
-		 * Parse the various X resources.  Thanks to Peter Canning.
-		 */
-		char *screen_resources, *display_resources, *geom,
-			*geomrestype, *home, *file, *dpitype;
-		XrmDatabase database;
-		XrmValue geomres, dpires;
+		char *geom, *geomrestype;
+		XrmValue geomres;
 
-		database = XrmGetDatabase(_x.display);
-		screen_resources = XScreenResourceString(xscreen);
-		if(screen_resources != nil){
-			XrmCombineDatabase(XrmGetStringDatabase(screen_resources), &database, False);
-			XFree(screen_resources);
-		}
-
-		display_resources = XResourceManagerString(_x.display);
-		if(display_resources == nil){
-			home = getenv("HOME");
-			if(home!=nil && (file=smprint("%s/.Xdefaults", home)) != nil){
-				XrmCombineFileDatabase(file, &database, False);
-				free(file);
-			}
-			free(home);
-		}else
-			XrmCombineDatabase(XrmGetStringDatabase(display_resources), &database, False);
-
-		if (XrmGetResource(database, "Xft.dpi", "String", &dpitype, &dpires) == True) {
-			if (dpires.addr) {
-				client->displaydpi = atoi(dpires.addr);
-			}
-		}
 		geom = smprint("%s.geometry", label);
 		if(geom && XrmGetResource(database, geom, nil, &geomrestype, &geomres))
 			mask = XParseGeometry(geomres.addr, &x, &y, (uint*)&width, (uint*)&height);
-		XrmDestroyDatabase(database);
 		free(geom);
 
 		if((mask & WidthValue) && (mask & HeightValue)){
@@ -634,6 +682,7 @@ xattach(Client *client, char *label, char *winsize)
 		}
 		havemin = 0;
 	}
+	XrmDestroyDatabase(database);
 	w = newxwin(client);
 
 	memset(&attr, 0, sizeof attr);


### PR DESCRIPTION
xattach built the X resource database only when the caller had not chosen a window size, so passing -W skipped the Xft.dpi lookup along with the geometry lookup and left displaydpi at 100.  Since scalesize does nothing below DefaultDPI, that disabled scaling entirely for any program started with -W.

Move the database and the resolution lookup into xresources() and xdpi() and call both unconditionally, using the database for geometry only when winsize is absent.

X cannot be asked for the resolution reliably: XWayland gives every output a zero physical size, and the core screen dimensions span all monitors at once, so on a multi-head display they describe no real screen.  xdpi() therefore tries $DEVDRAWDPI, the Xft.dpi resource, $GDK_SCALE and the physical screen size in turn, and disbelieves anything outside 50 to 600 dpi.  $DEVDRAWDPI is read in srv.c so that the mac and wayland backends honour it too.